### PR TITLE
Add AsanaUploadAction

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/actions/asana_upload_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/asana_upload_action.rb
@@ -1,0 +1,66 @@
+require "fastlane/action"
+require "fastlane_core/configuration/config_item"
+require "httparty"
+require_relative "../helper/ddg_apple_automation_helper"
+
+module Fastlane
+  module Actions
+    class AsanaUploadAction < Action
+      def self.run(params)
+        task_id = params[:task_id]
+        token = params[:asana_access_token]
+        file_name = params[:file_name]
+
+        begin
+          file = File.open(file_name)
+        rescue Errno::ENOENT
+          UI.user_error!("Failed to open file: #{file_name}")
+        end
+
+        url = Helper::DdgAppleAutomationHelper::ASANA_API_URL + "/tasks/#{task_id}/attachments"
+        response = HTTParty.post(url,
+                                 headers: { 'Authorization' => "Bearer #{token}" },
+                                 body: { file: file })
+
+        unless response.success?
+          UI.user_error!("Failed to upload file to Asana task: (#{response.code} #{response.message})")
+        end
+      end
+
+      def self.description
+        "Uploads a file to an Asana task"
+      end
+
+      def self.authors
+        ["DuckDuckGo"]
+      end
+
+      def self.return_value
+        ""
+      end
+
+      def self.details
+        # Optional:
+        ""
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.asana_access_token,
+          FastlaneCore::ConfigItem.new(key: :task_id,
+                                       description: "Asana task ID",
+                                       optional: false,
+                                       type: String),
+          FastlaneCore::ConfigItem.new(key: :file_name,
+                                       description: "Path to the file that will be uploaded",
+                                       optional: false,
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/asana_upload_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/asana_upload_action.rb
@@ -21,7 +21,7 @@ module Fastlane
           unless response.success?
             UI.user_error!("Failed to upload file to Asana task: (#{response.code} #{response.message})")
           end
-        rescue Errno::ENOENT
+        rescue StandardError
           UI.user_error!("Failed to open file: #{file_name}")
         end
       end

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/asana_upload_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/asana_upload_action.rb
@@ -13,17 +13,16 @@ module Fastlane
 
         begin
           file = File.open(file_name)
+          url = Helper::DdgAppleAutomationHelper::ASANA_API_URL + "/tasks/#{task_id}/attachments"
+          response = HTTParty.post(url,
+                                   headers: { 'Authorization' => "Bearer #{token}" },
+                                   body: { file: file })
+
+          unless response.success?
+            UI.user_error!("Failed to upload file to Asana task: (#{response.code} #{response.message})")
+          end
         rescue Errno::ENOENT
           UI.user_error!("Failed to open file: #{file_name}")
-        end
-
-        url = Helper::DdgAppleAutomationHelper::ASANA_API_URL + "/tasks/#{task_id}/attachments"
-        response = HTTParty.post(url,
-                                 headers: { 'Authorization' => "Bearer #{token}" },
-                                 body: { file: file })
-
-        unless response.success?
-          UI.user_error!("Failed to upload file to Asana task: (#{response.code} #{response.message})")
         end
       end
 

--- a/lib/fastlane/plugin/ddg_apple_automation/version.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module DdgAppleAutomation
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end

--- a/spec/asana_upload_action_spec.rb
+++ b/spec/asana_upload_action_spec.rb
@@ -24,6 +24,7 @@ describe Fastlane::Actions::AsanaUploadAction do
     it "shows error if file does not exist" do
       allow(HTTParty).to receive(:post).and_return(double(success?: true))
       expect(Fastlane::UI).to receive(:user_error!).with("Failed to open file: path/to/file.txt")
+      expect(HTTParty).not_to receive(:post)
       test_action("12345", "path/to/file.txt")
     end
   end

--- a/spec/asana_upload_action_spec.rb
+++ b/spec/asana_upload_action_spec.rb
@@ -1,0 +1,35 @@
+describe Fastlane::Actions::AsanaUploadAction do
+  describe "#run" do
+    it "uploads a file successfully" do
+      allow(HTTParty).to receive(:post).and_return(double(success?: true))
+      allow(File).to receive(:open).with("path/to/file.txt").and_return(double)
+
+      expect { test_action("12345", "path/to/file.txt") }.not_to raise_error
+    end
+
+    it "shows error if HTTP failure" do
+      allow(HTTParty).to receive(:post).and_return(
+        double(
+          success?: false,
+          code: 500,
+          message: "Internal Server Error"
+        )
+      )
+      allow(File).to receive(:open).with("path/to/file.txt").and_return(double)
+
+      expect(Fastlane::UI).to receive(:user_error!).with("Failed to upload file to Asana task: (500 Internal Server Error)")
+      test_action("12345", "path/to/file.txt")
+    end
+
+    it "shows error if file does not exist" do
+      allow(HTTParty).to receive(:post).and_return(double(success?: true))
+      expect(Fastlane::UI).to receive(:user_error!).with("Failed to open file: path/to/file.txt")
+      test_action("12345", "path/to/file.txt")
+    end
+  end
+
+  def test_action(task_id, file_name)
+    Fastlane::Actions::AsanaUploadAction.run(task_id: task_id,
+                                             file_name: file_name)
+  end
+end

--- a/spec/asana_upload_action_spec.rb
+++ b/spec/asana_upload_action_spec.rb
@@ -22,7 +22,6 @@ describe Fastlane::Actions::AsanaUploadAction do
     end
 
     it "shows error if file does not exist" do
-      allow(HTTParty).to receive(:post).and_return(double(success?: true))
       expect(Fastlane::UI).to receive(:user_error!).with("Failed to open file: path/to/file.txt")
       expect(HTTParty).not_to receive(:post)
       test_action("12345", "path/to/file.txt")


### PR DESCRIPTION
Task URL: https://app.asana.com/0/1201392122292466/1208137627434497/f

Description:
This change adds new lane that replaces asana-upload action