### PR TITLE
Don't create run-publish-dmg-release task when tag_release_action fails

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
@@ -125,17 +125,6 @@ module Fastlane
             github_handle: params[:github_handle],
             is_scheduled_release: params[:is_scheduled_release]
           )
-
-          if params[:is_internal_release_bump] && params[:platform] == "macos"
-            AsanaCreateActionItemAction.run(
-              asana_access_token: params[:asana_access_token],
-              task_url: params[:asana_task_url],
-              template_name: "run-publish-dmg-release",
-              template_args: template_args,
-              github_handle: params[:github_handle],
-              is_scheduled_release: params[:is_scheduled_release]
-            )
-          end
         end
 
         AsanaLogMessageAction.run(

--- a/lib/fastlane/plugin/ddg_apple_automation/version.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module DdgAppleAutomation
-    VERSION = "0.11.1"
+    VERSION = "0.11.2"
   end
 end

--- a/spec/tag_release_action_spec.rb
+++ b/spec/tag_release_action_spec.rb
@@ -385,21 +385,7 @@ describe Fastlane::Actions::TagReleaseAction do
 
         context "on macos" do
           include_context "on macos"
-
-          it "creates 2 Asana tasks where last one uses run-publish-dmg-release template and logs a message" do
-            subject
-            expect(Fastlane::Actions::TagReleaseAction).to have_received(:template_arguments).with(@params)
-            expect(Fastlane::Actions::TagReleaseAction).to have_received(:setup_asana_templates).with(@params)
-
-            calls = []
-            expect(Fastlane::Actions::AsanaCreateActionItemAction).to have_received(:run).twice do |*args|
-              calls << args.first
-            end
-
-            expect(calls.last).to include(template_name: "run-publish-dmg-release")
-            expect(Fastlane::Actions::AsanaLogMessageAction).to have_received(:run)
-            expect(template_args['task_id']).to eq(created_task_id)
-          end
+          it_behaves_like "creating Asana task and logging a message"
         end
       end
 


### PR DESCRIPTION
**Task/Issue URL:** https://app.asana.com/0/1203301625297703/1208705384164248/f

**Description:**
This change skips creating run-publish-dmg-release task after a failed merge/delete branch in tag_release_action.
That task should be created when the GHA workflow fails for an unrelated reason, but merge/delete error
isn't otherwise stopping the release workflow and manual intervention of the release DRI is not required. 
