### PR TITLE
Unit testing

### DIFF
--- a/spec/asana_helper_spec.rb
+++ b/spec/asana_helper_spec.rb
@@ -239,4 +239,395 @@ describe Fastlane::Helper::AsanaHelper do
       Fastlane::Helper::AsanaHelper.sanitize_asana_html_notes(content)
     end
   end
+
+  describe "#update_asana_tasks_for_internal_release" do
+    let(:params) do
+      {
+        github_token: "github_token",
+        asana_access_token: "secret-token",
+        release_task_id: "1234567890",
+        target_section_id: "987654321",
+        version: "7.122.0",
+        platform: "ios"
+      }
+    end
+
+    before do
+      @client = double("Octokit::Client")
+      allow(Octokit::Client).to receive(:new).and_return(@client)
+      allow(@client).to receive(:latest_release).and_return(double(tag_name: "7.122.0"))
+      allow(Fastlane::Helper::GitHelper).to receive(:repo_name).and_return("iOS")
+
+      @asana_client = double("Asana::Client")
+      @asana_tasks = double("Asana::Tasks")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:make_asana_client).and_return(@asana_client)
+      allow(@asana_client).to receive(:tasks).and_return(@asana_tasks)
+      allow(@asana_tasks).to receive(:update_task)
+      allow(@asana_tasks).to receive(:get_task).and_return(@asana_task)
+      allow(@asana_tasks).to receive(:get_subtasks_for_task).and_return([double(gid: "12312312313")])
+
+      allow(Fastlane::Helper::AsanaHelper).to receive(:asana_task_url).and_return("https://app.asana.com/0/1234567890/1234567890")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:fetch_release_notes).and_return("Release notes content")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:get_task_ids_from_git_log).and_return(["1234567890"])
+      allow(Fastlane::Helper::AsanaHelper).to receive(:release_tag_name).and_return("7.122.0")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:find_or_create_asana_release_tag).and_return("tag_id")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:move_tasks_to_section)
+      allow(Fastlane::Helper::AsanaHelper).to receive(:tag_tasks)
+    end
+
+    it "completes the update of Asana tasks for internal release" do
+      expect(@client).to receive(:latest_release).with("iOS")
+
+      expect(Fastlane::Helper::AsanaHelper).to receive(:fetch_release_notes).with("1234567890", "secret-token")
+      expect(Fastlane::Helper::ReleaseTaskHelper).to receive(:construct_release_task_description).with("Release notes content", ["1234567890"])
+      expect(Fastlane::Helper::AsanaHelper).to receive(:move_tasks_to_section).with(["1234567890", "1234567890"], "987654321", "secret-token")
+      expect(Fastlane::Helper::AsanaHelper).to receive(:tag_tasks).with("tag_id", ["1234567890", "1234567890"], "secret-token")
+
+      html_notes = "Generated HTML notes"
+      allow(Fastlane::Helper::ReleaseTaskHelper).to receive(:construct_release_task_description).and_return(html_notes)
+      expect(@asana_tasks).to receive(:update_task).with(task_gid: "1234567890", html_notes: html_notes)
+
+      expect(Fastlane::UI).to receive(:message).with("Checking latest public release in GitHub")
+      expect(Fastlane::UI).to receive(:success).with("Latest public release: 7.122.0")
+      expect(Fastlane::UI).to receive(:message).with("Extracting task IDs from git log since 7.122.0 release")
+      expect(Fastlane::UI).to receive(:success).with("1 task(s) found.")
+      expect(Fastlane::UI).to receive(:message).with("Fetching release notes from Asana release task (https://app.asana.com/0/1234567890/1234567890)")
+      expect(Fastlane::UI).to receive(:success).with("Release notes: Release notes content")
+      expect(Fastlane::UI).to receive(:message).with("Generating release task description using fetched release notes and task IDs")
+      expect(Fastlane::UI).to receive(:message).with("Updating release task")
+      expect(Fastlane::UI).to receive(:success).with("Release task content updated: https://app.asana.com/0/1234567890/1234567890")
+      expect(Fastlane::UI).to receive(:message).with("Moving tasks to Validation section")
+      expect(Fastlane::UI).to receive(:success).with("All tasks moved to Validation section")
+      expect(Fastlane::UI).to receive(:message).with("Fetching or creating 7.122.0 Asana tag")
+      expect(Fastlane::UI).to receive(:success).with("7.122.0 tag URL: https://app.asana.com/0/tag_id/list")
+      expect(Fastlane::UI).to receive(:message).with("Tagging tasks with 7.122.0 tag")
+      expect(Fastlane::UI).to receive(:success).with("All tasks tagged with 7.122.0 tag")
+
+      Fastlane::Helper::AsanaHelper.update_asana_tasks_for_internal_release(params)
+    end
+  end
+
+  describe ".create_release_task" do
+    let(:platform) { "ios" }
+    let(:version) { "7.112.09" }
+    let(:assignee_id) { "98765" }
+    let(:asana_access_token) { "token" }
+    let(:template_task_id) { "template123" }
+    let(:task_name) { "iOS App Release #{version}" }
+    let(:section_id) { "section789" }
+    let(:task_id) { "new_task_id" }
+    let(:task_url) { "https://app.asana.com/0/0/#{task_id}/f" }
+
+    before do
+      allow(Fastlane::Helper::AsanaHelper).to receive(:release_template_task_id).and_return(template_task_id)
+      allow(Fastlane::Helper::AsanaHelper).to receive(:release_task_name).and_return(task_name)
+      allow(Fastlane::Helper::AsanaHelper).to receive(:release_section_id).and_return(section_id)
+      allow(Fastlane::Helper::AsanaHelper).to receive(:asana_task_url).with(task_id).and_return(task_url)
+      allow(Fastlane::Helper::GitHubActionsHelper).to receive(:set_output)
+
+      @asana_client = double("Asana::Client")
+      @asana_tasks = double("Asana::Tasks")
+      @asana_sections = double("Asana::Sections")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:make_asana_client).and_return(@asana_client)
+      allow(@asana_client).to receive(:tasks).and_return(@asana_tasks)
+      allow(@asana_client).to receive(:sections).and_return(@asana_sections)
+
+      allow(Fastlane::UI).to receive(:message)
+      allow(Fastlane::UI).to receive(:success)
+    end
+
+    it "creates a release task successfully" do
+      allow(HTTParty).to receive(:post).and_return(double(success?: true, parsed_response: { 'data' => { 'new_task' => { 'gid' => task_id } } }))
+
+      expect(HTTParty).to receive(:post).with(
+        "#{Fastlane::Helper::AsanaHelper::ASANA_API_URL}/task_templates/#{template_task_id}/instantiateTask",
+        headers: { 'Authorization' => "Bearer #{asana_access_token}", 'Content-Type' => 'application/json' },
+        body: { data: { name: task_name } }.to_json
+      )
+
+      expect(@asana_sections).to receive(:add_task_for_section).with(section_gid: section_id, task: task_id)
+      expect(@asana_tasks).to receive(:update_task).with(task_gid: task_id, assignee: assignee_id)
+
+      Fastlane::Helper::AsanaHelper.create_release_task(platform, version, assignee_id, asana_access_token)
+
+      expect(Fastlane::UI).to have_received(:message).with("Creating release task for #{version}")
+      expect(Fastlane::Helper::GitHubActionsHelper).to have_received(:set_output).with("asana_task_id", task_id)
+      expect(Fastlane::Helper::GitHubActionsHelper).to have_received(:set_output).with("asana_task_url", task_url)
+      expect(Fastlane::UI).to have_received(:success).with("Release task for #{version} created at #{task_url}")
+      expect(Fastlane::UI).to have_received(:message).with("Moving release task to section #{section_id}")
+      expect(Fastlane::UI).to have_received(:message).with("Assigning release task to user #{assignee_id}")
+      expect(Fastlane::UI).to have_received(:success).with("Release task ready: #{task_url} ✅")
+    end
+
+    it "raises an error when task creation fails" do
+      allow(HTTParty).to receive(:post).and_return(double(success?: false, code: 500, message: "Internal Server Error"))
+
+      expect do
+        Fastlane::Helper::AsanaHelper.create_release_task(platform, version, assignee_id, asana_access_token)
+      end.to raise_error(FastlaneCore::Interface::FastlaneError, "Failed to instantiate task from template #{template_task_id}: (500 Internal Server Error)")
+    end
+  end
+
+  describe ".update_asana_tasks_for_public_release" do
+    let(:params) do
+      {
+        github_token: "github_token",
+        asana_access_token: "secret-token",
+        release_task_id: "1234567890",
+        target_section_id: "987654321",
+        version: "7.122.0",
+        platform: "ios"
+      }
+    end
+
+    let(:tag_name) { "7.122.0" }
+    let(:tag_id) { "7.122.0" }
+    let(:task_ids) { ["task1", "task2", "task3"] }
+    let(:release_notes) { "Release notes content" }
+
+    before do
+      allow(Fastlane::Helper::AsanaHelper).to receive(:release_tag_name).and_return(tag_name)
+      allow(Fastlane::Helper::AsanaHelper).to receive(:find_asana_release_tag).and_return(tag_id)
+      allow(Fastlane::Helper::AsanaHelper).to receive(:asana_tag_url).with(tag_id).and_return("https://app.asana.com/0/#{tag_id}/list")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:fetch_tasks_for_tag).and_return(task_ids)
+      allow(Fastlane::Helper::AsanaHelper).to receive(:move_tasks_to_section)
+      allow(Fastlane::Helper::AsanaHelper).to receive(:complete_tasks)
+      allow(Fastlane::Helper::AsanaHelper).to receive(:fetch_release_notes).and_return(release_notes)
+      allow(Fastlane::Helper::ReleaseTaskHelper).to receive(:construct_release_announcement_task_description)
+
+      allow(Fastlane::UI).to receive(:message)
+      allow(Fastlane::UI).to receive(:success)
+    end
+
+    it "updates Asana tasks for a public release" do
+      expect(Fastlane::Helper::AsanaHelper).to receive(:release_tag_name).with(params[:version], params[:platform])
+      expect(Fastlane::Helper::AsanaHelper).to receive(:find_asana_release_tag).with(tag_name, params[:release_task_id], params[:asana_access_token])
+      expect(Fastlane::Helper::AsanaHelper).to receive(:asana_tag_url).with(tag_id)
+      expect(Fastlane::Helper::AsanaHelper).to receive(:fetch_tasks_for_tag).with(tag_id, params[:asana_access_token])
+      expect(Fastlane::Helper::AsanaHelper).to receive(:move_tasks_to_section).with(task_ids, params[:target_section_id], params[:asana_access_token])
+      expect(Fastlane::Helper::AsanaHelper).to receive(:complete_tasks).with(task_ids, params[:asana_access_token])
+      expect(Fastlane::Helper::AsanaHelper).to receive(:fetch_release_notes).with(params[:release_task_id], params[:asana_access_token])
+      expect(Fastlane::Helper::ReleaseTaskHelper).to receive(:construct_release_announcement_task_description).with(params[:version], release_notes, task_ids - [params[:release_task_id]])
+      Fastlane::Helper::AsanaHelper.update_asana_tasks_for_public_release(params)
+
+      expect(Fastlane::UI).to have_received(:message).with("Fetching #{tag_name} Asana tag")
+      expect(Fastlane::UI).to have_received(:success).with("#{tag_name} tag URL: https://app.asana.com/0/#{tag_id}/list")
+      expect(Fastlane::UI).to have_received(:message).with("Fetching tasks tagged with #{tag_name}")
+      expect(Fastlane::UI).to have_received(:success).with("#{task_ids.count} task(s) found.")
+      expect(Fastlane::UI).to have_received(:message).with("Moving tasks to Done section")
+      expect(Fastlane::UI).to have_received(:success).with("All tasks moved to Done section")
+      expect(Fastlane::UI).to have_received(:message).with("Completing tasks")
+      expect(Fastlane::UI).to have_received(:message).with("Done completing tasks")
+      expect(Fastlane::UI).to have_received(:message).with("Fetching release notes from Asana release task (https://app.asana.com/0/0/1234567890/f)")
+      expect(Fastlane::UI).to have_received(:success).with("Release notes: #{release_notes}")
+      expect(Fastlane::UI).to have_received(:message).with("Preparing release announcement task")
+    end
+  end
+
+  describe ".fetch_tasks_for_tag" do
+    let(:tag_id) { "7.122.0" }
+    let(:task_ids) { ["12345", "67890", "54321"] }
+    let(:asana_access_token) { "secret-token" }
+
+    before do
+      @asana_client = double("Asana::Client")
+      @asana_tasks = double("Asana::Tasks")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:make_asana_client).with(asana_access_token).and_return(@asana_client)
+      allow(@asana_client).to receive(:tasks).and_return(@asana_tasks)
+      allow(Fastlane::UI).to receive(:user_error!)
+    end
+
+    it "fetches tasks for a given tag successfully with a next page" do
+      response_page1 = double(
+        "Asana::Collection",
+        data: [double(gid: "12345"), double(gid: "67890")],
+        next_page: double("next_page", offset: "eyJ0eXAiOJiKV1iQLCJhbGciOiJIUzI1NiJ9")
+      )
+
+      response_page2 = double(
+        "Asana::Collection",
+        data: [double(gid: "54321")]
+      )
+
+      allow(@asana_tasks).to receive(:get_tasks_for_tag)
+        .with(tag_gid: tag_id, options: { fields: ["gid"] })
+        .and_return(response_page1)
+      allow(@asana_tasks).to receive(:get_tasks_for_tag)
+        .with(tag_gid: tag_id, options: { fields: ["gid"], offset: "eyJ0eXAiOJiKV1iQLCJhbGciOiJIUzI1NiJ9" })
+        .and_return(response_page2)
+
+      result = Fastlane::Helper::AsanaHelper.fetch_tasks_for_tag(tag_id, asana_access_token)
+
+      expect(result).to eq(["12345", "67890", "54321"])
+    end
+
+    it "handles errors and raises a user error" do
+      allow(@asana_tasks).to receive(:get_tasks_for_tag).and_raise(StandardError, "API Error")
+      expect(Fastlane::UI).to receive(:user_error!).with("Failed to fetch tasks for tag: API Error")
+
+      result = Fastlane::Helper::AsanaHelper.fetch_tasks_for_tag(tag_id, asana_access_token)
+      expect(result).to eq([])
+    end
+  end
+
+  describe ".fetch_subtasks" do
+    let(:task_id) { "1234567890" }
+    let(:asana_access_token) { "secret-token" }
+
+    before do
+      @asana_client = double("Asana::Client")
+      @asana_tasks = double("Asana::Tasks")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:make_asana_client).with(asana_access_token).and_return(@asana_client)
+      allow(@asana_client).to receive(:tasks).and_return(@asana_tasks)
+      allow(Fastlane::UI).to receive(:user_error!)
+    end
+
+    it "fetches subtasks for a given task successfully" do
+      response_page1 = double(
+        "Asana::Collection",
+        data: [double(gid: "12345"), double(gid: "67890")],
+        next_page: double("next_page", offset: "eyJ0eXAiOJiKV1iQLCJhbGciOiJIUzI1NiJ9")
+      )
+
+      response_page2 = double(
+        "Asana::Collection",
+        data: [double(gid: "54321")]
+      )
+
+      allow(@asana_tasks).to receive(:get_subtasks_for_task)
+        .with(task_gid: task_id, options: { fields: ["gid"] })
+        .and_return(response_page1)
+
+      allow(@asana_tasks).to receive(:get_subtasks_for_task)
+        .with(task_gid: task_id, options: { fields: ["gid"], offset: "eyJ0eXAiOJiKV1iQLCJhbGciOiJIUzI1NiJ9" })
+        .and_return(response_page2)
+
+      result = Fastlane::Helper::AsanaHelper.fetch_subtasks(task_id, asana_access_token)
+
+      expect(result).to eq(["12345", "67890", "54321"])
+    end
+
+    it "handles errors when fetching subtasks" do
+      allow(@asana_tasks).to receive(:get_subtasks_for_task).and_raise(StandardError, "API Error")
+      expect(Fastlane::UI).to receive(:user_error!).with("Failed to fetch subtasks of task #{task_id}: API Error")
+
+      result = Fastlane::Helper::AsanaHelper.fetch_subtasks(task_id, asana_access_token)
+      expect(result).to eq([])
+    end
+  end
+
+  describe ".move_tasks_to_section" do
+    let(:task_ids) { ["task1", "task2", "task3"] }
+    let(:section_id) { "987654321" }
+    let(:asana_access_token) { "secret-token" }
+
+    before do
+      @asana_client = double("Asana::Client")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:make_asana_client).with(asana_access_token).and_return(@asana_client)
+      allow(@asana_client).to receive_message_chain(:batch_apis, :create_batch_request)
+      allow(Fastlane::UI).to receive(:message)
+    end
+
+    it "moves tasks to the specified section in batches" do
+      expect(Fastlane::UI).to receive(:message).with("Moving tasks task1, task2, task3 to section #{section_id}")
+      Fastlane::Helper::AsanaHelper.move_tasks_to_section(task_ids, section_id, asana_access_token)
+    end
+  end
+
+  describe ".complete_tasks" do
+    let(:task_ids) { ["1234567890", "1234567891", "1234567892"] }
+    let(:asana_access_token) { "secret-token" }
+    let(:incident_task_ids) { ["1234567890"] }
+
+    before do
+      @asana_client = double("Asana::Client")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:make_asana_client).with(asana_access_token).and_return(@asana_client)
+      allow(Fastlane::Helper::AsanaHelper).to receive(:fetch_subtasks).with(Fastlane::Helper::AsanaHelper::INCIDENTS_PARENT_TASK_ID, asana_access_token).and_return(incident_task_ids)
+      allow(@asana_client).to receive_message_chain(:projects, :get_projects_for_task)
+      allow(@asana_client).to receive_message_chain(:tasks, :update_task)
+    end
+
+    it "completes tasks while skipping incident and current objective tasks" do
+      allow(@asana_client.projects).to receive(:get_projects_for_task)
+        .with(task_gid: "1234567890", options: { fields: ["gid"] })
+        .and_return(double("response", data: [double(gid: Fastlane::Helper::AsanaHelper::INCIDENTS_PARENT_TASK_ID)]))
+      #
+      allow(@asana_client.projects).to receive(:get_projects_for_task)
+        .with(task_gid: "1234567891", options: { fields: ["gid"] })
+        .and_return(double("response", data: [double(gid: "non_objective_id")]))
+
+      allow(@asana_client.projects).to receive(:get_projects_for_task)
+        .with(task_gid: "1234567892", options: { fields: ["gid"] })
+        .and_return(double("response", data: [double(gid: Fastlane::Helper::AsanaHelper::CURRENT_OBJECTIVES_PROJECT_ID)]))
+
+      expect(Fastlane::UI).to receive(:important).with("Not completing task 1234567890 because it's an incident task")
+      expect(Fastlane::UI).to receive(:message).with("Completing task 1234567891")
+      expect(Fastlane::UI).to receive(:success).with("Task 1234567891 completed")
+      expect(Fastlane::UI).to receive(:important).with("Not completing task 1234567892 because it's a Current Objective")
+
+      Fastlane::Helper::AsanaHelper.complete_tasks(task_ids, asana_access_token)
+    end
+  end
+
+  describe ".find_asana_release_tag" do
+    let(:tag_name) { "7.122.0" }
+    let(:release_task_id) { "1234567890" }
+    let(:asana_access_token) { "secret-token" }
+
+    before do
+      @asana_client = double("Asana::Client")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:make_asana_client).with(asana_access_token).and_return(@asana_client)
+      allow(@asana_client).to receive_message_chain(:tasks, :get_task).and_return(double(tags: [double(name: tag_name, gid: "tag_id")]))
+    end
+
+    it "returns the tag ID when found in task tags" do
+      result = Fastlane::Helper::AsanaHelper.find_asana_release_tag(tag_name, release_task_id, asana_access_token)
+      expect(result).to eq("tag_id")
+    end
+  end
+
+  describe ".find_or_create_asana_release_tag" do
+    let(:tag_name) { "7.122.0" }
+    let(:release_task_id) { "1234567890" }
+    let(:asana_access_token) { "secret-token" }
+
+    before do
+      @asana_client = double("Asana::Client")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:make_asana_client).with(asana_access_token).and_return(@asana_client)
+    end
+
+    it "finds the release tag if it exists" do
+      allow(Fastlane::Helper::AsanaHelper).to receive(:find_asana_release_tag).and_return("tag_id")
+      result = Fastlane::Helper::AsanaHelper.find_or_create_asana_release_tag(tag_name, release_task_id, asana_access_token)
+      expect(result).to eq("tag_id")
+    end
+
+    it "creates the release tag if it does not exist" do
+      allow(Fastlane::Helper::AsanaHelper).to receive(:find_asana_release_tag).and_return(nil)
+      tags_client = double("Asana::Tags")
+      allow(@asana_client).to receive(:tags).and_return(tags_client)
+      allow(tags_client).to receive(:create_tag_for_workspace).and_return(double(gid: "new_tag_id"))
+
+      result = Fastlane::Helper::AsanaHelper.find_or_create_asana_release_tag(tag_name, release_task_id, asana_access_token)
+      expect(result).to eq("new_tag_id")
+    end
+  end
+
+  describe ".tag_tasks" do
+    let(:tag_id) { "7.122.0" }
+    let(:task_ids) { ["task1", "task2", "task3"] }
+    let(:asana_access_token) { "secret-token" }
+
+    before do
+      @asana_client = double("Asana::Client")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:make_asana_client).with(asana_access_token).and_return(@asana_client)
+      allow(@asana_client).to receive_message_chain(:batch_apis, :create_batch_request)
+      allow(Fastlane::UI).to receive(:message)
+    end
+
+    it "tags tasks in batches" do
+      expect(Fastlane::UI).to receive(:message).with("Tagging tasks task1, task2, task3")
+      Fastlane::Helper::AsanaHelper.tag_tasks(tag_id, task_ids, asana_access_token)
+    end
+  end
 end

--- a/spec/bump_build_number_action_spec.rb
+++ b/spec/bump_build_number_action_spec.rb
@@ -26,6 +26,24 @@ describe Fastlane::Actions::BumpBuildNumberAction do
     end
   end
 
+  describe "class methods" do
+    it "returns the correct description" do
+      expect(Fastlane::Actions::BumpBuildNumberAction.description).to eq("Prepares a subsequent internal release")
+    end
+
+    it "returns the correct authors" do
+      expect(Fastlane::Actions::BumpBuildNumberAction.authors).to eq(["DuckDuckGo"])
+    end
+
+    it "returns the correct return value description" do
+      expect(Fastlane::Actions::BumpBuildNumberAction.return_value).to eq("The newly created release task ID")
+    end
+
+    it "returns the correct details" do
+      expect(Fastlane::Actions::BumpBuildNumberAction.details).to eq("This action increments the project build number and pushes the changes to the remote repository.")
+    end
+  end
+
   def test_action(platform)
     params = { platform: platform }
     allow(params).to receive(:values).and_return(params)

--- a/spec/ddg_apple_automation_helper_spec.rb
+++ b/spec/ddg_apple_automation_helper_spec.rb
@@ -1,4 +1,10 @@
 describe Fastlane::Helper::DdgAppleAutomationHelper do
+  let(:other_action) { double("other_action") }
+  let(:platform) { "ios" }
+  let(:version) { "1.0.0" }
+  let(:asana_access_token) { "secret-token" }
+  let(:options) { { username: "user" } }
+
   describe "#process_erb_template" do
     it "processes ERB template" do
       template = "<h1>Hello, <%= x %>!</h1>"
@@ -55,6 +61,193 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
 
     def load_file(file)
       Fastlane::Helper::DdgAppleAutomationHelper.load_file(file)
+    end
+  end
+
+  describe ".code_freeze_prechecks" do
+    it "performs git and submodule checks" do
+      expect(other_action).to receive(:ensure_git_status_clean).twice
+      expect(other_action).to receive(:ensure_git_branch).with(branch: Fastlane::Helper::DdgAppleAutomationHelper::DEFAULT_BRANCH)
+      expect(other_action).to receive(:git_pull)
+      expect(other_action).to receive(:git_submodule_update).with(recursive: true, init: true)
+      Fastlane::Helper::DdgAppleAutomationHelper.code_freeze_prechecks(other_action)
+    end
+  end
+
+  describe ".validate_new_version" do
+    it "validates and returns the new version" do
+      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:current_version).and_return(version)
+      expect(Fastlane::UI).to receive(:important).with("Current version in project settings is #{version}.")
+      expect(Fastlane::UI).to receive(:important).with("New version is #{version}.")
+      allow(Fastlane::UI).to receive(:interactive?).and_return(true)
+      allow(Fastlane::UI).to receive(:confirm).and_return(true)
+      expect(Fastlane::Helper::DdgAppleAutomationHelper.validate_new_version(version)).to eq(version)
+    end
+  end
+
+  describe ".format_version" do
+    it "formats a version string" do
+      expect(Fastlane::Helper::DdgAppleAutomationHelper.format_version("1.2.3.4")).to eq("1.2.3")
+    end
+  end
+
+  describe ".bump_minor_version" do
+    it "increments the minor version" do
+      expect(Fastlane::Helper::DdgAppleAutomationHelper.bump_minor_version("1.2.0")).to eq("1.3.0")
+    end
+  end
+
+  describe ".bump_patch_version" do
+    it "increments the patch version" do
+      expect(Fastlane::Helper::DdgAppleAutomationHelper.bump_patch_version("1.2.3")).to eq("1.2.4")
+    end
+  end
+
+  describe ".current_build_number" do
+    it "reads the current build number from config" do
+      allow(File).to receive(:read).and_return("CURRENT_PROJECT_VERSION = 123")
+      expect(Fastlane::Helper::DdgAppleAutomationHelper.current_build_number).to eq(123)
+    end
+  end
+
+  describe ".current_version" do
+    it "reads the current version from config" do
+      allow(File).to receive(:read).and_return("MARKETING_VERSION = 1.2.3")
+      expect(Fastlane::Helper::DdgAppleAutomationHelper.current_version).to eq("1.2.3")
+    end
+  end
+
+  describe ".prepare_release_branch" do
+    it "prepares the release branch with version updates" do
+      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:code_freeze_prechecks)
+      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:validate_new_version).and_return(version)
+      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:create_release_branch)
+      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:update_embedded_files)
+      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:update_version_config)
+      expect(other_action).to receive(:push_to_git_remote)
+      release_branch, new_version = Fastlane::Helper::DdgAppleAutomationHelper.prepare_release_branch(platform, version, other_action)
+      expect(release_branch).to eq("#{Fastlane::Helper::DdgAppleAutomationHelper::RELEASE_BRANCH}/#{version}")
+      expect(new_version).to eq(version)
+    end
+  end
+
+  describe ".create_release_branch" do
+    it "creates a new release branch" do
+      allow(Fastlane::Actions).to receive(:sh).and_return("")
+      Fastlane::Helper::DdgAppleAutomationHelper.create_release_branch(version)
+      expect(Fastlane::Actions).to have_received(:sh).with("git", "branch", "--list", "release/#{version}")
+      expect(Fastlane::Actions).to have_received(:sh).with("git", "checkout", "-b", "release/#{version}")
+      expect(Fastlane::Actions).to have_received(:sh).with("git", "push", "-u", "origin", "release/#{version}")
+    end
+  end
+
+  describe ".update_embedded_files" do
+    it "updates embedded files and commits them" do
+      allow(Fastlane::Actions).to receive(:sh).with("./scripts/update_embedded.sh").and_return("")
+      git_status_output = "On branch main\nmodified: Core/trackerData.json\n"
+      allow(Fastlane::Actions).to receive(:sh).with("git", "status").and_return(git_status_output)
+      allow(Fastlane::Actions).to receive(:sh).with("git", "add", "Core/trackerData.json").and_return("")
+      allow(Fastlane::Actions).to receive(:sh).with("git", "commit", "-m", "Update embedded files").and_return("")
+      expect(other_action).to receive(:ensure_git_status_clean)
+      described_class.update_embedded_files(platform, other_action)
+      expect(Fastlane::Actions).to have_received(:sh).with("git", "status")
+      expect(Fastlane::Actions).to have_received(:sh).with("git", "add", "Core/trackerData.json")
+      expect(Fastlane::Actions).to have_received(:sh).with("git", "commit", "-m", "Update embedded files")
+    end
+  end
+
+  describe ".increment_build_number" do
+    it "increments the build number" do
+      allow(File).to receive(:read).with("Configuration/Version.xcconfig").and_return("MARKETING_VERSION = 1.0.0\n")
+      allow(File).to receive(:read).with("Configuration/BuildNumber.xcconfig").and_return("CURRENT_PROJECT_VERSION = 123\n")
+      allow(File).to receive(:write)
+      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:calculate_next_build_number).and_return(124)
+      allow(Fastlane::UI).to receive(:interactive?).and_return(false)
+      allow(Fastlane::UI).to receive(:confirm).and_return(true)
+      allow(Fastlane::UI).to receive(:select).and_return("Current release (123)")
+      expect(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:update_version_and_build_number_config)
+      expect(other_action).to receive(:push_to_git_remote)
+      Fastlane::Helper::DdgAppleAutomationHelper.increment_build_number(platform, options, other_action)
+    end
+  end
+
+  describe ".calculate_next_build_number" do
+    it "calculates the next build number" do
+      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:fetch_testflight_build_number).and_return(123)
+      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:current_build_number).and_return(124)
+      allow(Fastlane::UI).to receive(:interactive?).and_return(false)
+      expect(Fastlane::Helper::DdgAppleAutomationHelper.calculate_next_build_number(platform, options, other_action)).to eq(125)
+    end
+  end
+
+  describe ".fetch_appcast_build_number" do
+    it "fetches the highest appcast build number for macOS" do
+      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:`).with("plutil -extract SUFeedURL raw #{Fastlane::Helper::DdgAppleAutomationHelper::INFO_PLIST}").and_return("https://dummy-url.com/feed.xml\n")
+      allow(HTTParty).to receive(:get).with("https://dummy-url.com/feed.xml").and_return(
+        double(body: <<-XML
+          <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+            <channel>
+              <item>
+                <sparkle:version>100</sparkle:version>
+              </item>
+            </channel>
+          </rss>
+        XML
+              )
+      )
+
+      expect(Fastlane::Helper::DdgAppleAutomationHelper.fetch_appcast_build_number("macos")).to eq(100)
+    end
+  end
+
+  describe ".fetch_testflight_build_number" do
+    it "fetches the latest testflight build number" do
+      expect(other_action).to receive(:latest_testflight_build_number).and_return(125)
+      expect(Fastlane::Helper::DdgAppleAutomationHelper.fetch_testflight_build_number(platform, options, other_action)).to eq(125)
+    end
+  end
+
+  describe ".get_api_key" do
+    it "returns the API key if available in environment" do
+      ENV["APPLE_API_KEY_ID"] = "key_id"
+      ENV["APPLE_API_KEY_ISSUER"] = "issuer_id"
+      ENV["APPLE_API_KEY_BASE64"] = "key_base64"
+      expect(other_action).to receive(:app_store_connect_api_key).with(
+        key_id: "key_id", issuer_id: "issuer_id", key_content: "key_base64", is_key_content_base64: true
+      )
+      Fastlane::Helper::DdgAppleAutomationHelper.get_api_key(other_action)
+    end
+  end
+
+  describe ".get_username" do
+    it "fetches the username from options or git config" do
+      allow(`git config user.email`).to receive(:chomp).and_return("test@duckduckgo.com")
+      expect(Fastlane::Helper::DdgAppleAutomationHelper.get_username(username: "username")).to eq("username")
+    end
+  end
+
+  describe ".update_version_config" do
+    it "updates the version in the config file" do
+      expect(File).to receive(:write).with(
+        Fastlane::Helper::DdgAppleAutomationHelper::VERSION_CONFIG_PATH,
+        "#{Fastlane::Helper::DdgAppleAutomationHelper::VERSION_CONFIG_DEFINITION} = #{version}\n"
+      )
+
+      expect(other_action).to receive(:git_commit).with(
+        path: Fastlane::Helper::DdgAppleAutomationHelper::VERSION_CONFIG_PATH,
+        message: "Set marketing version to #{version}"
+      )
+
+      Fastlane::Helper::DdgAppleAutomationHelper.update_version_config(version, other_action)
+    end
+  end
+
+  describe ".update_version_and_build_number_config" do
+    it "updates both version and build number in config files" do
+      expect(File).to receive(:write).with(Fastlane::Helper::DdgAppleAutomationHelper::VERSION_CONFIG_PATH, "#{Fastlane::Helper::DdgAppleAutomationHelper::VERSION_CONFIG_DEFINITION} = #{version}\n")
+      expect(File).to receive(:write).with(Fastlane::Helper::DdgAppleAutomationHelper::BUILD_NUMBER_CONFIG_PATH, "#{Fastlane::Helper::DdgAppleAutomationHelper::BUILD_NUMBER_CONFIG_DEFINITION} = 123\n")
+      expect(other_action).to receive(:git_commit)
+      Fastlane::Helper::DdgAppleAutomationHelper.update_version_and_build_number_config(version, 123, other_action)
     end
   end
 end

--- a/spec/github_actions_helper_spec.rb
+++ b/spec/github_actions_helper_spec.rb
@@ -52,6 +52,47 @@ describe Fastlane::Helper::GitHubActionsHelper do
     end
   end
 
+  describe ".assert_branch_has_changes" do
+    before do
+      allow(Fastlane::UI).to receive(:important)
+    end
+
+    context "when the release branch has no changes since the latest tag" do
+      it "returns false and shows a message" do
+        allow(Fastlane::Helper::GitHelper).to receive(:`).with("git describe --tags --abbrev=0").and_return("v1.0.0\n")
+        allow(Fastlane::Helper::GitHelper).to receive(:`).with('git rev-parse "v1.0.0"^{}').and_return("abc123\n")
+        allow(Fastlane::Helper::GitHelper).to receive(:`).with('git rev-parse "origin/release_branch"').and_return("abc123\n")
+
+        expect(Fastlane::Helper::GitHelper.assert_branch_has_changes("release_branch")).to eq(false)
+        expect(Fastlane::UI).to have_received(:important).with("Release branch's HEAD is already tagged. Skipping automatic release.")
+      end
+    end
+
+    context "when the release branch has changes since the latest tag" do
+      it "returns true" do
+        allow(Fastlane::Helper::GitHelper).to receive(:`).with("git describe --tags --abbrev=0").and_return("v1.0.0\n")
+        allow(Fastlane::Helper::GitHelper).to receive(:`).with('git rev-parse "v1.0.0"^{}').and_return("abc123\n")
+        allow(Fastlane::Helper::GitHelper).to receive(:`).with('git rev-parse "origin/release_branch"').and_return("def456\n")
+        allow(Fastlane::Helper::GitHelper).to receive(:`).with('git diff --name-only "v1.0.0".."origin/release_branch"')
+          .and_return("app/file1.rb\napp/file2.rb\n")
+
+        expect(Fastlane::Helper::GitHelper.assert_branch_has_changes("release_branch")).to eq(true)
+      end
+    end
+
+    context "when changes are only in scripts or workflows" do
+      it "returns false" do
+        allow(Fastlane::Helper::GitHelper).to receive(:`).with("git describe --tags --abbrev=0").and_return("v1.0.0\n")
+        allow(Fastlane::Helper::GitHelper).to receive(:`).with('git rev-parse "v1.0.0"^{}').and_return("abc123\n")
+        allow(Fastlane::Helper::GitHelper).to receive(:`).with('git rev-parse "origin/release_branch"').and_return("def456\n")
+        allow(Fastlane::Helper::GitHelper).to receive(:`).with('git diff --name-only "v1.0.0".."origin/release_branch"')
+          .and_return(".github/workflows/workflow.yml\nscripts/deploy.sh\nfastlane/Fastfile\n")
+
+        expect(Fastlane::Helper::GitHelper.assert_branch_has_changes("release_branch")).to eq(false)
+      end
+    end
+  end
+
   def set_output(key, value)
     Fastlane::Helper::GitHubActionsHelper.set_output(key, value)
   end

--- a/spec/start_new_release_action_spec.rb
+++ b/spec/start_new_release_action_spec.rb
@@ -1,0 +1,156 @@
+shared_context "common setup" do
+  before do
+    @params = {
+      asana_access_token: "secret-token",
+      github_token: "github_token",
+      github_handle: "user",
+      target_section_id: "12345",
+      version: "1.0.0"
+    }
+
+    allow(Fastlane::Helper::GitHelper).to receive(:setup_git_user)
+    allow(Fastlane::Helper::AsanaHelper).to receive(:get_asana_user_id_for_github_handle).and_return("user")
+    allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:prepare_release_branch).and_return(["release_branch_name", "1.1.0"])
+    allow(Fastlane::Helper::AsanaHelper).to receive(:create_release_task).and_return("1234567890")
+    allow(Fastlane::Helper::AsanaHelper).to receive(:update_asana_tasks_for_internal_release)
+    allow(Fastlane::Actions).to receive(:lane_context).and_return({ Fastlane::Actions::SharedValues::PLATFORM_NAME => "ios" })
+
+    other_action_double = double("other_action")
+    allow(other_action_double).to receive(:setup_constants)
+    allow(Fastlane::Actions).to receive(:other_action).and_return(other_action_double)
+  end
+end
+
+shared_context "on ios" do
+  before do
+    @params[:platform] = "ios"
+    allow(Fastlane::Actions.other_action).to receive(:setup_constants).with(@params[:platform])
+  end
+end
+
+shared_context "on macos" do
+  before do
+    @params[:platform] = "macos"
+    allow(Fastlane::Actions.other_action).to receive(:setup_constants).with(@params[:platform])
+  end
+end
+
+
+describe Fastlane::Actions::StartNewReleaseAction do
+  describe '#run' do
+    subject do
+      configuration = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::StartNewReleaseAction, @params)
+      Fastlane::Actions::StartNewReleaseAction.run(configuration)
+    end
+
+    include_context "common setup"
+
+    context "on ios" do
+      include_context "on ios"
+
+      it 'sets up git user' do
+        subject
+        expect(Fastlane::Helper::GitHelper).to have_received(:setup_git_user)
+      end
+
+      it 'gets Asana user ID based on GitHub handle' do
+        subject
+        expect(Fastlane::Helper::AsanaHelper).to have_received(:get_asana_user_id_for_github_handle).with("user")
+      end
+
+      it 'prepares the release branch' do
+        subject
+        expect(Fastlane::Helper::DdgAppleAutomationHelper).to have_received(:prepare_release_branch).with("ios", "1.0.0", anything)
+      end
+
+      it 'creates a release task in Asana' do
+        subject
+        expect(Fastlane::Helper::AsanaHelper).to have_received(:create_release_task).with("ios", "1.1.0", "user", "secret-token")
+      end
+
+      it 'updates Asana tasks for internal release' do
+        subject
+        expect(Fastlane::Helper::AsanaHelper).to have_received(:update_asana_tasks_for_internal_release).with(
+          hash_including(
+            platform: "ios",
+            version: "1.1.0",
+            release_branch_name: "release_branch_name",
+            release_task_id: "1234567890",
+            asana_access_token: "secret-token"
+          )
+        )
+      end
+    end
+
+    context "on macos" do
+      include_context "on macos"
+
+      it 'sets up git user' do
+        subject
+        expect(Fastlane::Helper::GitHelper).to have_received(:setup_git_user)
+      end
+
+      it 'gets Asana user ID based on GitHub handle' do
+        subject
+        expect(Fastlane::Helper::AsanaHelper).to have_received(:get_asana_user_id_for_github_handle).with("user")
+      end
+
+      it 'prepares the release branch' do
+        subject
+        expect(Fastlane::Helper::DdgAppleAutomationHelper).to have_received(:prepare_release_branch).with("macos", "1.0.0", anything)
+      end
+
+      it 'creates a release task in Asana' do
+        subject
+        expect(Fastlane::Helper::AsanaHelper).to have_received(:create_release_task).with("macos", "1.1.0", "user", "secret-token")
+      end
+
+      it 'updates Asana tasks for internal release' do
+        subject
+        expect(Fastlane::Helper::AsanaHelper).to have_received(:update_asana_tasks_for_internal_release).with(
+          hash_including(
+            platform: "macos",
+            version: "1.1.0",
+            release_branch_name: "release_branch_name",
+            release_task_id: "1234567890",
+            asana_access_token: "secret-token"
+          )
+        )
+      end
+    end
+  end
+
+  # Constants
+  describe '#available_options' do
+    it 'includes the necessary configuration items' do
+      options = Fastlane::Actions::StartNewReleaseAction.available_options.map(&:key)
+      expect(options).to include(:asana_access_token, :github_token, :platform, :version, :github_handle, :target_section_id)
+    end
+  end
+
+  describe '#is_supported?' do
+    it 'supports macos and ios platforms' do
+      expect(Fastlane::Actions::StartNewReleaseAction.is_supported?(:macos)).to be true
+      expect(Fastlane::Actions::StartNewReleaseAction.is_supported?(:ios)).to be true
+    end
+  end
+
+  describe '.description' do
+    it 'returns the description' do
+      expect(described_class.description).to eq("Starts a new release")
+    end
+  end
+
+  describe '.authors' do
+    it 'returns the authors' do
+      expect(described_class.authors).to include("DuckDuckGo")
+    end
+  end
+
+  describe '.return_value' do
+    it 'returns the return value description' do
+      expect(described_class.return_value).to eq("The newly created release task ID")
+    end
+  end
+
+end

--- a/spec/update_asana_for_release_action_spec.rb
+++ b/spec/update_asana_for_release_action_spec.rb
@@ -1,0 +1,80 @@
+describe Fastlane::Actions::UpdateAsanaForReleaseAction do
+  describe ".run" do
+    let(:params) do
+      {
+        asana_access_token: "secret-token",
+        github_token: "github_token",
+        is_scheduled_release: true,
+        platform: "ios",
+        github_handle: "github_user",
+        release_task_id: "1234567890",
+        release_type: release_type,
+        target_section_id: "987654321"
+      }
+    end
+    
+    subject do
+      configuration = FastlaneCore::Configuration.create(Fastlane::Actions::UpdateAsanaForReleaseAction.available_options, params)
+      Fastlane::Actions::UpdateAsanaForReleaseAction.run(configuration)
+    end
+
+    before do
+      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:current_version).and_return("1.1.0")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:asana_task_url).and_return("https://app.asana.com/0/1234567890/1234567890")
+      allow(Fastlane::Actions::AsanaCreateActionItemAction).to receive(:run)
+    end
+
+    context "when release type is internal" do
+      let(:release_type) { "internal" }
+
+      it "updates Asana tasks for internal release" do
+        expect(Fastlane::Helper::AsanaHelper).to receive(:update_asana_tasks_for_internal_release).with(hash_including(release_task_id: "1234567890"))
+        subject
+      end
+    end
+
+    context "when release type is public" do
+      let(:release_type) { "public" }
+
+      before do
+        allow(Fastlane::Helper::AsanaHelper).to receive(:update_asana_tasks_for_public_release).and_return("Announcement task notes")
+      end
+
+      it "updates Asana tasks for public release" do
+        expect(Fastlane::Helper::AsanaHelper).to receive(:update_asana_tasks_for_public_release).with(hash_including(release_task_id: "1234567890"))
+        subject
+      end
+
+      it "creates an announcement task in Asana" do
+        subject
+        expect(Fastlane::Actions::AsanaCreateActionItemAction).to have_received(:run).with(
+          asana_access_token: "secret-token",
+          task_url: "https://app.asana.com/0/1234567890/1234567890",
+          task_name: "Announce the release to the company",
+          html_notes: "Announcement task notes",
+          github_handle: "github_user",
+          is_scheduled_release: true
+        )
+      end
+    end
+  end
+
+  describe ".available_options" do
+    it "includes the necessary configuration items" do
+      options = Fastlane::Actions::UpdateAsanaForReleaseAction.available_options.map(&:key)
+      expect(options).to include(:asana_access_token, :github_token, :platform, :github_handle, :release_task_id, :release_type, :target_section_id)
+    end
+  end
+
+  describe ".description" do
+    it "returns the description" do
+      expect(Fastlane::Actions::UpdateAsanaForReleaseAction.description).to eq("Processes tasks included in the release and the Asana release task")
+    end
+  end
+
+  describe ".authors" do
+    it "returns the authors" do
+      expect(Fastlane::Actions::UpdateAsanaForReleaseAction.authors).to eq(["DuckDuckGo"])
+    end
+  end
+end

--- a/spec/validate_internal_release_bump_action_spec.rb
+++ b/spec/validate_internal_release_bump_action_spec.rb
@@ -1,0 +1,140 @@
+describe Fastlane::Actions::ValidateInternalReleaseBumpAction do
+  shared_context "common setup" do
+    before do
+      @params = {
+        asana_access_token: "secret-token",
+        github_token: "github_token",
+        platform: "ios",
+        release_task_url: nil
+      }
+
+      allow(Fastlane::Helper::GitHelper).to receive(:setup_git_user)
+      allow(Fastlane::Helper::GitHelper).to receive(:assert_branch_has_changes).and_return(true)
+      allow(Fastlane::Helper::GitHubActionsHelper).to receive(:set_output)
+      allow(Fastlane::Helper::AsanaHelper).to receive(:fetch_release_notes).and_return("Valid release notes")
+      allow(Fastlane::Helper::AsanaHelper).to receive(:extract_asana_task_id).and_return("987654321")
+      allow(Fastlane::Actions).to receive(:lane_context).and_return({ Fastlane::Actions::SharedValues::PLATFORM_NAME => "ios" })
+
+
+      @other_action = double(ensure_git_branch: nil, git_branch: "release_branch_name")
+      allow(Fastlane::Action).to receive(:other_action).and_return(@other_action)
+      allow(Fastlane::Actions).to receive(:other_action).and_return(@other_action)
+      allow(Fastlane::Actions::AsanaFindReleaseTaskAction).to receive(:find_latest_marketing_version)
+        .and_return("1.0.0")
+
+      allow(Fastlane::Actions::ValidateInternalReleaseBumpAction).to receive(:find_release_task_if_needed) do |params|
+        params[:release_branch] = "release_branch_name"
+        params[:release_task_id] = "mock_task_id"
+      end
+        
+    end
+  end
+
+  shared_context "on ios" do
+    before do
+      @params[:platform] = "ios"
+    end
+  end
+
+  shared_context "on macos" do
+    before do
+      @params[:platform] = "macos"
+    end
+  end
+
+  describe "#run" do
+    subject do
+      configuration = FastlaneCore::Configuration.create(Fastlane::Actions::ValidateInternalReleaseBumpAction.available_options, @params)
+      Fastlane::Actions::ValidateInternalReleaseBumpAction.run(configuration)      
+    end
+    include_context "common setup"
+    
+    context "when there are changes in the release branch" do
+      it "proceeds with release bump if release notes are valid" do
+        expect(Fastlane::UI).to receive(:message).with("Validating release notes")
+        expect(Fastlane::UI).to receive(:message).with("Release notes are valid: Valid release notes")
+        subject
+      end
+
+      it "raises an error if release notes contain placeholder text" do
+        allow(Fastlane::Helper::AsanaHelper).to receive(:fetch_release_notes).and_return("<-- Add release notes here -->")
+        expect(Fastlane::UI).to receive(:message).with("Validating release notes")
+        expect(Fastlane::UI).to receive(:user_error!).with("Release notes are empty or contain a placeholder. Please add release notes to the Asana task and restart the workflow.")
+        subject
+      end
+    end
+
+    context "when there are no changes in the release branch" do
+      it "skips the release" do
+        allow(Fastlane::Helper::GitHelper).to receive(:assert_branch_has_changes).and_return(false)
+        expect(Fastlane::UI).to receive(:important).with("No changes to the release branch (or only changes to scripts and workflows). Skipping automatic release.")
+        expect(Fastlane::Helper::GitHubActionsHelper).to receive(:set_output).with("skip_release", true)
+        subject
+      end
+    end
+  end
+
+  describe "#find_release_task_if_needed" do
+    include_context "common setup"
+
+    context "when release_task_url is provided" do
+      it "sets release_task_id and release_branch from release_task_url" do
+        allow(Fastlane::Actions::ValidateInternalReleaseBumpAction).to receive(:find_release_task_if_needed).and_call_original
+        @params[:release_task_url] = "https://app.asana.com/0/1234567890/987654321"
+        Fastlane::Actions::ValidateInternalReleaseBumpAction.find_release_task_if_needed(@params)
+
+        expect(Fastlane::Helper::AsanaHelper).to have_received(:extract_asana_task_id).with(@params[:release_task_url], set_gha_output: false)
+        expect(Fastlane::Actions.other_action).to have_received(:ensure_git_branch).with(branch: "^release/.+$")
+        expect(@params[:release_branch]).to eq("release_branch_name")
+        expect(@params[:release_task_id]).to eq("987654321")
+      end
+    end
+
+    context "when release_task_url is not provided" do
+      it "runs AsanaFindReleaseTaskAction to find the release task" do
+        allow(Fastlane::Actions::ValidateInternalReleaseBumpAction).to receive(:find_release_task_if_needed).and_call_original
+        allow(Fastlane::Actions::AsanaFindReleaseTaskAction).to receive(:run).and_return({ release_task_id: "1234567890", release_branch: "release_branch_name" })
+        Fastlane::Actions::ValidateInternalReleaseBumpAction.find_release_task_if_needed(@params)
+
+        expect(Fastlane::Actions::AsanaFindReleaseTaskAction).to have_received(:run).with(
+          asana_access_token: "secret-token",
+          github_token: "github_token",
+          platform: "ios"
+        )
+        expect(@params[:release_task_id]).to eq("1234567890")
+        expect(@params[:release_branch]).to eq("release_branch_name")
+      end
+    end
+  end
+
+  # Constants and Configuration
+  describe "constants and configuration" do
+    it "returns the description" do
+      expect(Fastlane::Actions::ValidateInternalReleaseBumpAction.description).to eq("Performs checks to decide if a subsequent internal release should be made")
+    end
+
+    it "returns the authors" do
+      expect(Fastlane::Actions::ValidateInternalReleaseBumpAction.authors).to eq(["DuckDuckGo"])
+    end
+
+    it "returns the correct details" do
+      expected_details = <<-DETAILS
+This action performs the following tasks:
+* finds the git branch and Asana task for the current internal release,
+* checks for changes to the release branch,
+* ensures that release notes aren't empty or placeholder.
+      DETAILS
+      expect(Fastlane::Actions::ValidateInternalReleaseBumpAction.details.strip).to eq(expected_details.strip)
+    end
+
+    it "includes the necessary configuration items" do
+      options = Fastlane::Actions::ValidateInternalReleaseBumpAction.available_options.map(&:key)
+      expect(options).to include(:asana_access_token, :github_token, :platform, :release_task_url)
+    end
+
+    it "supports macos and ios platforms" do
+      expect(Fastlane::Actions::ValidateInternalReleaseBumpAction.is_supported?(:macos)).to be true
+      expect(Fastlane::Actions::ValidateInternalReleaseBumpAction.is_supported?(:ios)).to be true
+    end
+  end
+end


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/0/72649045549333/1208137627434479/f

Description:
Adds unit tests for the following
-  start_new_release action
-  bump_build_number action
-  update_asana_for_release
-  validate_internal_release_bump

Also adds unit tests coverage for sub functionality in 
- ddg_apple_automation_helper.rb
- asana_helper.rb

Minor bugfix for task processing, 
- get_tasks_for_tag/get_subtasks_for_task returns an object wrapped in `data` to access `gid` rather than directly mapping it
- Fixed breaking out of loop early when completing multiple tasks 
- 
