### PR TITLE
Only check for changes to the branch for scheduled releases

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/actions/validate_internal_release_bump_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/validate_internal_release_bump_action.rb
@@ -14,7 +14,7 @@ module Fastlane
         options = params.values
         find_release_task_if_needed(options)
 
-        unless Helper::GitHelper.assert_branch_has_changes(options[:release_branch])
+        if params[:is_scheduled_release] && !Helper::GitHelper.assert_branch_has_changes(options[:release_branch])
           UI.important("No changes to the release branch (or only changes to scripts and workflows). Skipping automatic release.")
           Helper::GitHubActionsHelper.set_output("skip_release", true)
           return

--- a/spec/validate_internal_release_bump_action_spec.rb
+++ b/spec/validate_internal_release_bump_action_spec.rb
@@ -63,11 +63,29 @@ describe Fastlane::Actions::ValidateInternalReleaseBumpAction do
     end
 
     context "when there are no changes in the release branch" do
-      it "skips the release" do
+      before do
         allow(Fastlane::Helper::GitHelper).to receive(:assert_branch_has_changes).and_return(false)
-        expect(Fastlane::UI).to receive(:important).with("No changes to the release branch (or only changes to scripts and workflows). Skipping automatic release.")
-        expect(Fastlane::Helper::GitHubActionsHelper).to receive(:set_output).with("skip_release", true)
-        subject
+      end
+
+      context "when it's a scheduled release" do
+        before do
+          @params[:is_scheduled_release] = true
+        end
+
+        it "skips the release" do
+          allow(Fastlane::Helper::GitHelper).to receive(:assert_branch_has_changes).and_return(false)
+          expect(Fastlane::UI).to receive(:important).with("No changes to the release branch (or only changes to scripts and workflows). Skipping automatic release.")
+          expect(Fastlane::Helper::GitHubActionsHelper).to receive(:set_output).with("skip_release", true)
+          subject
+        end
+      end
+
+      context "when it's not a scheduled release" do
+        it "proceeds with release bump if release notes are valid" do
+          expect(Fastlane::UI).to receive(:message).with("Validating release notes")
+          expect(Fastlane::UI).to receive(:message).with("Release notes are valid: Valid release notes")
+          subject
+        end
       end
     end
   end


### PR DESCRIPTION
This is to allow running Bump Internal Release out of schedule for an already tagged branch, as needed.