### PR TITLE
Asana fixes for iOS release flow

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/public-release-complete-ios.html.erb
+++ b/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/public-release-complete-ios.html.erb
@@ -1,0 +1,3 @@
+<body>
+  Build <%= tag %> is now available publicly via App Store.<br>
+</body>

--- a/lib/fastlane/plugin/ddg_apple_automation/assets/release_task_helper/templates/release_announcement_task_description.html.erb
+++ b/lib/fastlane/plugin/ddg_apple_automation/assets/release_task_helper/templates/release_announcement_task_description.html.erb
@@ -1,7 +1,7 @@
 <body>
   As the last step of the process, post a message to <a href='https://app.asana.com/0/11984721910118/1204991209236659'>REVIEW / RELEASE</a> Asana project:
   <ul>
-    <li>Set the title to <strong>macOS App Release <%= marketing_version %></strong></li>
+    <li>Set the title to <strong><%= platform == "ios" ? "iOS App Release" : "macOS App Release" %> <%= marketing_version %></strong></li>
     <li>Copy the content below (between separators) and paste as the message body.</li>
   </ul>
   <hr>
@@ -14,8 +14,12 @@
   <% end %>
   </ul>
   <strong>Rollout</strong><br>
-  This is now rolling out to users. New users will receive this release immediately, 
+  <% if platform == "ios" %>This is now rolling out to users. New users will receive this release immediately, 
+  existing users will receive this gradually over the next few days until we reach a 5% threshold. 
+  If there are no problems we will push the release to everyone. 
+  You can force an update now by going to the App Store, finding the Update tab and downloading the latest version.
+  <% else %>This is now rolling out to users. New users will receive this release immediately, 
   existing users will receive this gradually over the next few days. You can force an update now 
-  by going to the DuckDuckGo menu in the menu bar and selecting "Check For Updates".
+  by going to the DuckDuckGo menu in the menu bar and selecting "Check For Updates".<% end %>
   <hr>
 </body>

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/asana_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/asana_helper.rb
@@ -293,7 +293,7 @@ module Fastlane
 
         # Construct release announcement task description
         UI.message("Preparing release announcement task")
-        Helper::ReleaseTaskHelper.construct_release_announcement_task_description(params[:version], release_notes, task_ids)
+        Helper::ReleaseTaskHelper.construct_release_announcement_task_description(params[:version], release_notes, task_ids, params[:platform])
       end
 
       def self.fetch_tasks_for_tag(tag_id, asana_access_token)

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/release_task_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/release_task_helper.rb
@@ -18,12 +18,13 @@ module Fastlane
         Helper::AsanaHelper.sanitize_asana_html_notes(html_notes)
       end
 
-      def self.construct_release_announcement_task_description(version, release_notes, task_ids)
+      def self.construct_release_announcement_task_description(version, release_notes, task_ids, platform)
         template_file = Helper::DdgAppleAutomationHelper.path_for_asset_file("release_task_helper/templates/release_announcement_task_description.html.erb")
         html_notes = Helper::DdgAppleAutomationHelper.process_erb_template(template_file, {
           marketing_version: version,
           release_notes: release_notes,
-          task_ids: task_ids
+          task_ids: task_ids,
+          platform: platform
         })
         Helper::AsanaHelper.sanitize_asana_html_notes(html_notes)
       end

--- a/lib/fastlane/plugin/ddg_apple_automation/version.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module DdgAppleAutomation
-    VERSION = "1.0.2"
+    VERSION = "1.0.3"
   end
 end

--- a/spec/asana_helper_spec.rb
+++ b/spec/asana_helper_spec.rb
@@ -394,7 +394,7 @@ describe Fastlane::Helper::AsanaHelper do
       expect(Fastlane::Helper::AsanaHelper).to receive(:move_tasks_to_section).with(task_ids, params[:target_section_id], params[:asana_access_token])
       expect(Fastlane::Helper::AsanaHelper).to receive(:complete_tasks).with(task_ids, params[:asana_access_token])
       expect(Fastlane::Helper::AsanaHelper).to receive(:fetch_release_notes).with(params[:release_task_id], params[:asana_access_token])
-      expect(Fastlane::Helper::ReleaseTaskHelper).to receive(:construct_release_announcement_task_description).with(params[:version], release_notes, task_ids - [params[:release_task_id]])
+      expect(Fastlane::Helper::ReleaseTaskHelper).to receive(:construct_release_announcement_task_description).with(params[:version], release_notes, task_ids - [params[:release_task_id]], "ios")
       Fastlane::Helper::AsanaHelper.update_asana_tasks_for_public_release(params)
 
       expect(Fastlane::UI).to have_received(:message).with("Fetching #{tag_name} Asana tag")


### PR DESCRIPTION
1. Release announcement now accepts platform param to determine wording for task
2. New template for public release ios