### PR TITLE
Update `compute_tag` to support a platform suffix

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
@@ -382,7 +382,7 @@ module Fastlane
         erb_template.result_with_hash(args)
       end
 
-      def self.compute_tag(is_prerelease)
+      def self.compute_tag(is_prerelease, platform_suffix)
         version = File.read(VERSION_CONFIG_PATH).chomp.split(" = ").last
         build_number = File.read(BUILD_NUMBER_CONFIG_PATH).chomp.split(" = ").last
         if is_prerelease
@@ -390,6 +390,11 @@ module Fastlane
         else
           tag = version
           promoted_tag = "#{version}-#{build_number}"
+        end
+
+        if platform_suffix && !platform_suffix.empty?
+          tag = "#{tag}+#{platform_suffix}"
+          promoted_tag = "#{promoted_tag}+#{platform_suffix}" unless is_prerelease
         end
 
         return tag, promoted_tag

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
@@ -394,7 +394,7 @@ module Fastlane
         erb_template.result_with_hash(args)
       end
 
-      def self.compute_tag(is_prerelease, platform_suffix)
+      def self.compute_tag(is_prerelease, platform)
         version = File.read(VERSION_CONFIG_PATH).chomp.split(" = ").last
         build_number = File.read(BUILD_NUMBER_CONFIG_PATH).chomp.split(" = ").last
         if is_prerelease
@@ -404,9 +404,9 @@ module Fastlane
           promoted_tag = "#{version}-#{build_number}"
         end
 
-        if platform_suffix && !platform_suffix.empty?
-          tag = "#{tag}+#{platform_suffix}"
-          promoted_tag = "#{promoted_tag}+#{platform_suffix}" unless is_prerelease
+        if platform && !platform.empty?
+          tag = "#{tag}+#{platform}"
+          promoted_tag = "#{promoted_tag}+#{platform}" unless is_prerelease
         end
 
         return tag, promoted_tag

--- a/spec/ddg_apple_automation_helper_spec.rb
+++ b/spec/ddg_apple_automation_helper_spec.rb
@@ -28,50 +28,50 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
   describe "#compute_tag" do
     describe "when is prerelease" do
       let(:is_prerelease) { true }
-      let(:platform_suffix) { nil }
+      let(:platform) { nil }
 
       it "computes tag and returns nil promoted tag" do
         allow(File).to receive(:read).with("Configuration/Version.xcconfig").and_return("MARKETING_VERSION = 1.0.0")
         allow(File).to receive(:read).with("Configuration/BuildNumber.xcconfig").and_return("CURRENT_PROJECT_VERSION = 123")
-        expect(compute_tag(is_prerelease, platform_suffix)).to eq(["1.0.0-123", nil])
+        expect(compute_tag(is_prerelease, platform)).to eq(["1.0.0-123", nil])
       end
     end
 
     describe "when is public release" do
       let(:is_prerelease) { false }
-      let(:platform_suffix) { nil }
+      let(:platform) { nil }
 
       it "computes tag and promoted tag" do
         allow(File).to receive(:read).with("Configuration/Version.xcconfig").and_return("MARKETING_VERSION = 1.0.0")
         allow(File).to receive(:read).with("Configuration/BuildNumber.xcconfig").and_return("CURRENT_PROJECT_VERSION = 123")
-        expect(compute_tag(is_prerelease, platform_suffix)).to eq(["1.0.0", "1.0.0-123"])
+        expect(compute_tag(is_prerelease, platform)).to eq(["1.0.0", "1.0.0-123"])
       end
     end
 
     describe "when is prerelease and includes platform suffix" do
       let(:is_prerelease) { true }
-      let(:platform_suffix) { 'suffix' }
+      let(:platform) { 'suffix' }
 
       it "computes tag and returns nil promoted tag" do
         allow(File).to receive(:read).with("Configuration/Version.xcconfig").and_return("MARKETING_VERSION = 1.0.0")
         allow(File).to receive(:read).with("Configuration/BuildNumber.xcconfig").and_return("CURRENT_PROJECT_VERSION = 123")
-        expect(compute_tag(is_prerelease, platform_suffix)).to eq(["1.0.0-123+suffix", nil])
+        expect(compute_tag(is_prerelease, platform)).to eq(["1.0.0-123+suffix", nil])
       end
     end
 
     describe "when is public release and includes platform suffix" do
       let(:is_prerelease) { false }
-      let(:platform_suffix) { 'suffix' }
+      let(:platform) { 'suffix' }
 
       it "computes tag and returns nil promoted tag" do
         allow(File).to receive(:read).with("Configuration/Version.xcconfig").and_return("MARKETING_VERSION = 1.0.0")
         allow(File).to receive(:read).with("Configuration/BuildNumber.xcconfig").and_return("CURRENT_PROJECT_VERSION = 123")
-        expect(compute_tag(is_prerelease, platform_suffix)).to eq(["1.0.0+suffix", "1.0.0-123+suffix"])
+        expect(compute_tag(is_prerelease, platform)).to eq(["1.0.0+suffix", "1.0.0-123+suffix"])
       end
     end
 
-    def compute_tag(is_prerelease, platform_suffix)
-      Fastlane::Helper::DdgAppleAutomationHelper.compute_tag(is_prerelease, platform_suffix)
+    def compute_tag(is_prerelease, platform)
+      Fastlane::Helper::DdgAppleAutomationHelper.compute_tag(is_prerelease, platform)
     end
   end
 

--- a/spec/ddg_apple_automation_helper_spec.rb
+++ b/spec/ddg_apple_automation_helper_spec.rb
@@ -28,26 +28,50 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
   describe "#compute_tag" do
     describe "when is prerelease" do
       let(:is_prerelease) { true }
+      let(:platform_suffix) { nil }
 
       it "computes tag and returns nil promoted tag" do
         allow(File).to receive(:read).with("Configuration/Version.xcconfig").and_return("MARKETING_VERSION = 1.0.0")
         allow(File).to receive(:read).with("Configuration/BuildNumber.xcconfig").and_return("CURRENT_PROJECT_VERSION = 123")
-        expect(compute_tag(is_prerelease)).to eq(["1.0.0-123", nil])
+        expect(compute_tag(is_prerelease, platform_suffix)).to eq(["1.0.0-123", nil])
       end
     end
 
     describe "when is public release" do
       let(:is_prerelease) { false }
+      let(:platform_suffix) { nil }
 
       it "computes tag and promoted tag" do
         allow(File).to receive(:read).with("Configuration/Version.xcconfig").and_return("MARKETING_VERSION = 1.0.0")
         allow(File).to receive(:read).with("Configuration/BuildNumber.xcconfig").and_return("CURRENT_PROJECT_VERSION = 123")
-        expect(compute_tag(is_prerelease)).to eq(["1.0.0", "1.0.0-123"])
+        expect(compute_tag(is_prerelease, platform_suffix)).to eq(["1.0.0", "1.0.0-123"])
       end
     end
 
-    def compute_tag(is_prerelease)
-      Fastlane::Helper::DdgAppleAutomationHelper.compute_tag(is_prerelease)
+    describe "when is prerelease and includes platform suffix" do
+      let(:is_prerelease) { true }
+      let(:platform_suffix) { 'suffix' }
+
+      it "computes tag and returns nil promoted tag" do
+        allow(File).to receive(:read).with("Configuration/Version.xcconfig").and_return("MARKETING_VERSION = 1.0.0")
+        allow(File).to receive(:read).with("Configuration/BuildNumber.xcconfig").and_return("CURRENT_PROJECT_VERSION = 123")
+        expect(compute_tag(is_prerelease, platform_suffix)).to eq(["1.0.0-123+suffix", nil])
+      end
+    end
+
+    describe "when is public release and includes platform suffix" do
+      let(:is_prerelease) { false }
+      let(:platform_suffix) { 'suffix' }
+
+      it "computes tag and returns nil promoted tag" do
+        allow(File).to receive(:read).with("Configuration/Version.xcconfig").and_return("MARKETING_VERSION = 1.0.0")
+        allow(File).to receive(:read).with("Configuration/BuildNumber.xcconfig").and_return("CURRENT_PROJECT_VERSION = 123")
+        expect(compute_tag(is_prerelease, platform_suffix)).to eq(["1.0.0+suffix", "1.0.0-123+suffix"])
+      end
+    end
+
+    def compute_tag(is_prerelease, platform_suffix)
+      Fastlane::Helper::DdgAppleAutomationHelper.compute_tag(is_prerelease, platform_suffix)
     end
   end
 


### PR DESCRIPTION
Task: https://app.asana.com/0/72649045549333/1209258986834819/f

This PR updates the `compute_tag` function to optionally take a suffix, which then gets appended to the tag to allow us to compute tags with the format of: `major.minor.patch.build+suffix`.

This will be used when we begin building tags that need to be disambiguated in the monorepo, e.g. `7.123.0.0+ios`.

**How to test:**
1. Check that CI is green