### PR TITLE
Update release fetching to optionally match tags with a platform component

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
@@ -59,10 +59,7 @@ module Fastlane
       end
 
       def self.find_latest_marketing_version(github_token, platform)
-        client = Octokit::Client.new(access_token: github_token)
-
-        # NOTE: `client.latest_release` returns release marked as "latest", i.e. a public release
-        latest_internal_release = client.releases(Helper::GitHelper.repo_name(platform), { per_page: 1 }).first
+        latest_internal_release = Helper::GitHelper.latest_release(Helper::GitHelper.repo_name(platform), true, github_token)
 
         version = extract_version_from_tag_name(latest_internal_release&.tag_name)
         if version.to_s.empty?

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
@@ -63,8 +63,8 @@ module Fastlane
         end
 
         begin
-          client = Octokit::Client.new(access_token: github_token)
-          latest_public_release = client.latest_release(@constants[:repo_name])
+          latest_public_release = Helper::GitHelper.latest_release(@constants[:repo_name], false, github_token)
+
           UI.message("Latest public release: #{latest_public_release.tag_name}")
           UI.message("Generating #{@constants[:repo_name]} release notes for GitHub release for tag: #{tag}")
 

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/asana_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/asana_helper.rb
@@ -219,8 +219,8 @@ module Fastlane
       #
       def self.update_asana_tasks_for_internal_release(params)
         UI.message("Checking latest public release in GitHub")
-        client = Octokit::Client.new(access_token: params[:github_token])
-        latest_public_release = client.latest_release(Helper::GitHelper.repo_name(params[:platform]))
+
+        latest_public_release = Helper::GitHelper.latest_release(Helper::GitHelper.repo_name(params[:platform]), false, params[:github_token])
         UI.success("Latest public release: #{latest_public_release.tag_name}")
 
         UI.message("Extracting task IDs from git log since #{latest_public_release.tag_name} release")

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
@@ -157,8 +157,7 @@ module Fastlane
       end
 
       def self.prepare_hotfix_branch(github_token, platform, other_action, options)
-        client = Octokit::Client.new(access_token: github_token)
-        latest_public_release = client.latest_release(Helper::GitHelper.repo_name(platform))
+        latest_public_release = Helper::GitHelper.latest_release(Helper::GitHelper.repo_name(platform), false, github_token)
         version = latest_public_release.tag_name
         Helper::GitHubActionsHelper.set_output("last_release", version)
         UI.user_error!("Unable to find latest release to hotfix") unless version

--- a/spec/asana_find_release_task_action_spec.rb
+++ b/spec/asana_find_release_task_action_spec.rb
@@ -35,9 +35,17 @@ describe Fastlane::Actions::AsanaFindReleaseTaskAction do
     end
 
     it "returns the latest marketing version" do
-      allow(@client).to receive(:releases).and_return([double(tag_name: '1.0.0')])
+      allow(@client).to receive(:releases).and_return(
+        [
+          double(tag_name: '2.0.0-1', prerelease: true),
+          double(tag_name: '2.0.0-0', prerelease: true),
+          double(tag_name: '1.0.0', prerelease: false),
+          double(tag_name: '1.0.0-1', prerelease: true),
+          double(tag_name: '1.0.0-0', prerelease: true)
+        ]
+      )
 
-      expect(find_latest_marketing_version).to eq("1.0.0")
+      expect(find_latest_marketing_version).to eq("2.0.0")
     end
 
     describe "when there is no latest release" do
@@ -53,7 +61,7 @@ describe Fastlane::Actions::AsanaFindReleaseTaskAction do
 
     describe "when latest release is not a valid semver" do
       it "shows error" do
-        allow(@client).to receive(:releases).and_return([double(tag_name: '1.0')])
+        allow(@client).to receive(:releases).and_return([double(tag_name: '1.0', prerelease: false)])
         allow(Fastlane::UI).to receive(:user_error!)
 
         find_latest_marketing_version

--- a/spec/asana_helper_spec.rb
+++ b/spec/asana_helper_spec.rb
@@ -242,7 +242,8 @@ describe Fastlane::Helper::AsanaHelper do
     before do
       @client = double("Octokit::Client")
       allow(Octokit::Client).to receive(:new).and_return(@client)
-      allow(@client).to receive(:latest_release).and_return(double(tag_name: "7.122.0"))
+      allow(@client).to receive(:releases).with("iOS", { page: 1, per_page: 25 }).and_return([double(tag_name: "7.122.0", prerelease: false)])
+      allow(@client).to receive(:releases).with("iOS", { page: 2, per_page: 25 }).and_return([])
       allow(Fastlane::Helper::GitHelper).to receive(:repo_name).and_return("iOS")
 
       @asana_client = double("Asana::Client")
@@ -263,7 +264,7 @@ describe Fastlane::Helper::AsanaHelper do
     end
 
     it "completes the update of Asana tasks for internal release" do
-      expect(@client).to receive(:latest_release).with("iOS")
+      expect(@client).to receive(:releases).with("iOS", { page: 1, per_page: 25 })
 
       expect(Fastlane::Helper::AsanaHelper).to receive(:fetch_release_notes).with("1234567890", "secret-token")
       expect(Fastlane::Helper::ReleaseTaskHelper).to receive(:construct_release_task_description).with("Release notes content", ["1234567890"])

--- a/spec/ddg_apple_automation_helper_spec.rb
+++ b/spec/ddg_apple_automation_helper_spec.rb
@@ -282,7 +282,7 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
 
       @client = double("Octokit::Client")
       allow(Octokit::Client).to receive(:new).and_return(@client)
-      allow(@client).to receive(:latest_release).and_return(double(tag_name: source_version))
+      allow(@client).to receive(:releases).and_return([double(tag_name: source_version, prerelease: false)])
       allow(Fastlane::Helper::GitHelper).to receive(:repo_name).and_return("macOS")
 
       allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:validate_version_exists)
@@ -332,7 +332,7 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
 
       @client = double("Octokit::Client")
       allow(Octokit::Client).to receive(:new).and_return(@client)
-      allow(@client).to receive(:latest_release).and_return(double(tag_name: source_version))
+      allow(@client).to receive(:releases).and_return([double(tag_name: source_version, prerelease: false)])
       allow(Fastlane::Helper::GitHelper).to receive(:repo_name).and_return("iOS")
 
       allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:validate_version_exists)

--- a/spec/tag_release_action_spec.rb
+++ b/spec/tag_release_action_spec.rb
@@ -105,10 +105,10 @@ describe Fastlane::Actions::TagReleaseAction do
   describe "#create_tag_and_github_release" do
     subject { Fastlane::Actions::TagReleaseAction.create_tag_and_github_release(@params[:is_prerelease], @params[:github_token]) }
 
-    let (:latest_public_release) { double(tag_name: "1.0.0") }
+    let (:latest_public_release) { double(tag_name: "1.0.0", prerelease: false) }
     let (:generated_release_notes) { { body: { "name" => "1.1.0", "body" => "Release notes" } } }
     let (:other_action) { double(add_git_tag: nil, push_git_tags: nil, github_api: generated_release_notes, set_github_release: nil) }
-    let (:octokit_client) { double(latest_release: latest_public_release) }
+    let (:octokit_client) { double(releases: [latest_public_release]) }
 
     shared_context "local setup" do
       before(:each) do
@@ -174,7 +174,7 @@ describe Fastlane::Actions::TagReleaseAction do
 
     shared_context "when failed to fetch latest GitHub release" do
       before do
-        allow(octokit_client).to receive(:latest_release).and_raise(StandardError)
+        allow(octokit_client).to receive(:releases).and_raise(StandardError)
       end
     end
 


### PR DESCRIPTION
Task: https://app.asana.com/0/72649045549333/1209266752736135/f

This PR updates the GitHub release lookup logic to look through all releases in our repos and find the relevant release for the platform. It's implemented to keep working the way it always has for now, but when we're ready we would start passing the `platform` string into the lookup function and start getting back releases with a `+platform` string at the end.

**How to test:**
1. Check that CI is green and that new test cases correctly test the behavior
2. Verify that the changes don't break existed release logic
3. Maybe do a proper test release in the test repo? I haven't done this yet, and have only relied on unit tests to verify the changes