### PR TITLE
Add an action to generate Sentry grouping rules for crash reports

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/actions/generate_sentry_grouping_rules_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/generate_sentry_grouping_rules_action.rb
@@ -1,8 +1,5 @@
 require "fastlane/action"
 require "fastlane_core/configuration/config_item"
-require "octokit"
-require "tmpdir"
-require "fileutils"
 require_relative "../helper/sentry_helper"
 
 module Fastlane

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/generate_sentry_grouping_rules_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/generate_sentry_grouping_rules_action.rb
@@ -1,0 +1,43 @@
+require "fastlane/action"
+require "fastlane_core/configuration/config_item"
+require "octokit"
+require "tmpdir"
+require "fileutils"
+require_relative "../helper/sentry_helper"
+
+module Fastlane
+  module Actions
+    class GenerateSentryGroupingRulesAction < Action
+      def self.run(params)
+        params[:platform] ||= Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
+        Helper::SentryHelper.generate_grouping_rules(params[:platform], params[:output_file])
+      end
+
+      def self.description
+        "Generate Sentry Grouping Rules (to treat symbols from local packages as app symbols)"
+      end
+
+      def self.authors
+        ["DuckDuckGo"]
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.platform,
+          FastlaneCore::ConfigItem.new(key: :output_file,
+                                       description: "File to write the grouping rules to",
+                                       optional: false,
+                                       type: String)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+
+      def self.return_value
+        "The generated Sentry grouping rules in a newline-separated list"
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/sentry_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/sentry_helper.rb
@@ -1,0 +1,52 @@
+require "fastlane/action"
+require "fastlane_core/ui/ui"
+
+module Fastlane
+  UI = FastlaneCore::UI unless Fastlane.const_defined?(:UI)
+
+  module Helper
+    class SentryHelper
+      COMMON_APP_MODULES = [
+        'GRDB'
+      ].freeze
+
+      APP_MODULES = {
+        "ios" => [
+          'Core'
+        ],
+        "macos" => []
+      }.freeze
+
+      def self.generate_grouping_rules(platform, output_file)
+        UI.message("Starting Sentry Grouping Rules Generation...")
+
+        app_modules = COMMON_APP_MODULES + APP_MODULES[platform]
+        app_modules += find_modules_in_package_files
+        app_modules = format_sentry_grouping_rules(app_modules)
+
+        formatted_app_modules = app_modules.join("\n")
+
+        File.write(output_file, formatted_app_modules)
+        formatted_app_modules
+      end
+
+      def self.find_modules_in_package_files
+        modules = []
+        package_files = Actions.sh("git ls-files **/Package.swift ../SharedPackages/**/Package.swift").chomp.split("\n")
+        package_files.each do |package_file|
+          next unless File.exist?(package_file)
+
+          content = File.read(package_file)
+          content.scan(/\.library\s*\(\s*name:\s*"([^"]+)"/) do |match|
+            modules << match[0]
+          end
+        end
+        modules
+      end
+
+      def self.format_sentry_grouping_rules(modules)
+        modules.map { |module_name| "stack.package:#{module_name} +app" }.sort!.uniq
+      end
+    end
+  end
+end


### PR DESCRIPTION
Task URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1210200963473616?focus=true

This change adds an action that generates Sentry grouping rules that treat symbols from
all local packages as in-app symbols.

The tests aren’t provided - I relied on manual testing for now. Happy to add tests later.