### PR TITLE
Update DBP bundle resource path

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/helper/embedded_files_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/embedded_files_helper.rb
@@ -23,7 +23,7 @@ module Fastlane
                                'DuckDuckGo/ContentBlocker/AppTrackerDataSetProvider.swift',
                                'DuckDuckGo/ContentBlocker/trackerData.json',
                                'DuckDuckGo/ContentBlocker/macos-config.json',
-                               '../SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Resources/JSON/*.json'
+                               '../SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/BundleResources/JSON/*.json'
                              ])
         }.freeze
 

--- a/lib/fastlane/plugin/ddg_apple_automation/version.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module DdgAppleAutomation
-    VERSION = "2.3.0"
+    VERSION = "2.3.1"
   end
 end

--- a/spec/ddg_apple_automation_helper_spec.rb
+++ b/spec/ddg_apple_automation_helper_spec.rb
@@ -564,10 +564,10 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
 
     it "updates embedded files and commits them" do
       allow(Fastlane::Actions).to receive(:sh).with("./scripts/update_embedded.sh").and_return("")
-      git_status_output = " M DuckDuckGo/ContentBlocker/trackerData.json\n?? ../SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Resources/JSON/backgroundcheck.json\n"
+      git_status_output = " M DuckDuckGo/ContentBlocker/trackerData.json\n?? ../SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/BundleResources/JSON/backgroundcheck.json\n"
       allow(Fastlane::Actions).to receive(:sh).with("git", "status", "-s").and_return(git_status_output)
       allow(Fastlane::Actions).to receive(:sh).with("git", "add", "DuckDuckGo/ContentBlocker/trackerData.json").and_return("")
-      allow(Fastlane::Actions).to receive(:sh).with("git", "add", "../SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Resources/JSON/backgroundcheck.json").and_return("")
+      allow(Fastlane::Actions).to receive(:sh).with("git", "add", "../SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/BundleResources/JSON/backgroundcheck.json").and_return("")
       allow(Fastlane::Actions).to receive(:sh).with("git", "commit", "-m", "Update embedded files").and_return("")
       allow(other_action).to receive(:tds_perf_test).and_return(true)
       allow(other_action).to receive(:ensure_git_status_clean)
@@ -576,7 +576,7 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
       described_class.update_embedded_files(platform, other_action)
       expect(Fastlane::Actions).to have_received(:sh).with("git", "status", "-s")
       expect(Fastlane::Actions).to have_received(:sh).with("git", "add", "DuckDuckGo/ContentBlocker/trackerData.json")
-      expect(Fastlane::Actions).to have_received(:sh).with("git", "add", "../SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/Resources/JSON/backgroundcheck.json")
+      expect(Fastlane::Actions).to have_received(:sh).with("git", "add", "../SharedPackages/DataBrokerProtectionCore/Sources/DataBrokerProtectionCore/BundleResources/JSON/backgroundcheck.json")
       expect(Fastlane::Actions).to have_received(:sh).with("git", "commit", "-m", "Update embedded files")
     end
   end


### PR DESCRIPTION
The `Resources` directory for broker JSON storage was [recently](https://github.com/duckduckgo/apple-browsers/pull/646) renamed to `BundleResources`. This updates the path to reflect it.

