### PR TITLE
Update retrieving build version from the appcast file

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/actions/bump_build_number_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/bump_build_number_action.rb
@@ -34,7 +34,6 @@ module Fastlane
 
       def self.available_options
         [
-          FastlaneCore::ConfigItem.asana_access_token,
           FastlaneCore::ConfigItem.github_token,
           FastlaneCore::ConfigItem.platform
         ]

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/calculate_next_build_number_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/calculate_next_build_number_action.rb
@@ -1,0 +1,48 @@
+require "fastlane/action"
+require "fastlane_core/configuration/config_item"
+require_relative "../helper/ddg_apple_automation_helper"
+
+module Fastlane
+  module Actions
+    class CalculateNextBuildNumberAction < Action
+      def self.run(params)
+        Helper::GitHelper.setup_git_user
+        params[:platform] ||= Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
+        options = params.values
+        Helper::DdgAppleAutomationHelper.calculate_next_build_number(options[:platform], options, options[:config], options[:bundle_id], other_action)
+      end
+
+      def self.description
+        "Calculates the next build number for a given configuration and bundle ID"
+      end
+
+      def self.authors
+        ["DuckDuckGo"]
+      end
+
+      def self.return_value
+        "The next build number"
+      end
+
+      def self.details
+        "This action calculates the next build number for a given configuration and bundle ID."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.platform,
+          FastlaneCore::ConfigItem.string(key: :config,
+                                          description: "The configuration to use for the build number",
+                                          default_value: "release"),
+          FastlaneCore::ConfigItem.string(key: :bundle_id,
+                                          description: "The bundle ID to use for the build number",
+                                          default_value: nil)
+        ]
+      end
+
+      def self.is_supported?(platform)
+        platform == "macos"
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
@@ -278,7 +278,6 @@ module Fastlane
         # (e.g. SPARKLE_URL_ALPHA for Alpha or SPARKLE_URL_RELEASE for Release)
         url = File.readlines(SPARKLE_CONFIG_PATH)
                   .find { |l| l.downcase.start_with?("sparkle_url_#{config.downcase} = ") }
-                  .first
                   .chomp
                   .split(' = ')
                   .last
@@ -286,7 +285,7 @@ module Fastlane
 
         request = HTTParty.get(url)
         unless request.success?
-          UI.message("Failed to fetch appcast for #{config}: #{request.response.code} #{request.response.message}")
+          UI.message("Failed to fetch appcast for '#{config}' configuration from #{url}: #{request.response.code} #{request.response.message}")
           return 0
         end
 
@@ -302,7 +301,7 @@ module Fastlane
           username: get_username(options),
           platform: platform == "macos" ? "osx" : "ios"
         }
-        args[:bundle_id] = bundle_id if bundle_id
+        args[:app_identifier] = bundle_id if bundle_id
         other_action.latest_testflight_build_number(args)
       end
 

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
@@ -20,6 +20,7 @@ module Fastlane
       ROOT_PLIST = 'DuckDuckGo/Settings.bundle/Root.plist'
       VERSION_CONFIG_PATH = 'Configuration/Version.xcconfig'
       BUILD_NUMBER_CONFIG_PATH = 'Configuration/BuildNumber.xcconfig'
+      SPARKLE_CONFIG_PATH = 'Configuration/App/Sparkle.xcconfig'
       VERSION_CONFIG_DEFINITION = 'MARKETING_VERSION'
       BUILD_NUMBER_CONFIG_DEFINITION = 'CURRENT_PROJECT_VERSION'
 
@@ -232,11 +233,11 @@ module Fastlane
         other_action.push_to_git_remote
       end
 
-      def self.calculate_next_build_number(platform, options, other_action)
-        testflight_build_number = fetch_testflight_build_number(platform, options, other_action)
+      def self.calculate_next_build_number(platform, options, config = "release", bundle_id = nil, other_action)
+        testflight_build_number = fetch_testflight_build_number(platform, options, bundle_id, other_action)
         xcodeproj_build_number = current_build_number
         if platform == "macos"
-          appcast_build_number = fetch_appcast_build_number(platform)
+          appcast_build_number = fetch_appcast_build_number(config)
           current_release_build_number = [testflight_build_number, appcast_build_number].max
         else
           current_release_build_number = testflight_build_number
@@ -271,21 +272,38 @@ module Fastlane
         new_build_number + 1
       end
 
-      def self.fetch_appcast_build_number(platform)
-        UI.user_error!("This function is not supported on iOS") if platform == "ios"
-        url = `plutil -extract SUFeedURL raw #{INFO_PLIST}`.chomp
-        xml = HTTParty.get(url).body
+      def self.fetch_appcast_build_number(config)
+        # This logic depends on the Sparkle.xcconfig file to contain the keys in the following format:
+        # SPARKLE_URL_<CONFIG> for appcast URL for a given config
+        # (e.g. SPARKLE_URL_ALPHA for Alpha or SPARKLE_URL_RELEASE for Release)
+        url = File.readlines(SPARKLE_CONFIG_PATH)
+                  .find { |l| l.downcase.start_with?("sparkle_url_#{config.downcase} = ") }
+                  .first
+                  .chomp
+                  .split(' = ')
+                  .last
+                  .tr('"', '')
+
+        request = HTTParty.get(url)
+        unless request.success?
+          UI.message("Failed to fetch appcast for #{config}: #{request.response.code} #{request.response.message}")
+          return 0
+        end
+
+        xml = request.body
         xml_data = REXML::Document.new(xml)
         versions = xml_data.get_elements('//rss/channel/item/sparkle:version').map { |e| e.text.split('.')[0].to_i }
         versions.max
       end
 
-      def self.fetch_testflight_build_number(platform, options, other_action)
-        other_action.latest_testflight_build_number(
+      def self.fetch_testflight_build_number(platform, options, bundle_id, other_action)
+        args = {
           api_key: get_api_key(other_action),
           username: get_username(options),
           platform: platform == "macos" ? "osx" : "ios"
-        )
+        }
+        args[:bundle_id] = bundle_id if bundle_id
+        other_action.latest_testflight_build_number(args)
       end
 
       def self.get_api_key(other_action)

--- a/spec/ddg_apple_automation_helper_spec.rb
+++ b/spec/ddg_apple_automation_helper_spec.rb
@@ -607,28 +607,32 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
 
   describe "#fetch_appcast_build_number" do
     it "fetches the highest appcast build number for macOS" do
-      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:`).with("plutil -extract SUFeedURL raw #{Fastlane::Helper::DdgAppleAutomationHelper::INFO_PLIST}").and_return("https://dummy-url.com/feed.xml\n")
-      allow(HTTParty).to receive(:get).with("https://dummy-url.com/feed.xml").and_return(
-        double(body: <<-XML
-          <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
-            <channel>
-              <item>
-                <sparkle:version>100</sparkle:version>
-              </item>
-            </channel>
-          </rss>
-        XML
-              )
-      )
+      allow(File).to receive(:readlines).with(Fastlane::Helper::DdgAppleAutomationHelper::SPARKLE_CONFIG_PATH).and_return(["SPARKLE_URL_RELEASE = \"https://dummy-url.com/feed.xml\"\n"])
+      allow(HTTParty).to receive(:get)
+        .with("https://dummy-url.com/feed.xml")
+        .and_return(
+          double(
+            success?: true,
+            body: <<-XML
+              <rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle">
+                <channel>
+                  <item>
+                    <sparkle:version>100</sparkle:version>
+                  </item>
+                </channel>
+              </rss>
+            XML
+          )
+        )
 
-      expect(Fastlane::Helper::DdgAppleAutomationHelper.fetch_appcast_build_number("macos")).to eq(100)
+      expect(Fastlane::Helper::DdgAppleAutomationHelper.fetch_appcast_build_number("release")).to eq(100)
     end
   end
 
   describe "#fetch_testflight_build_number" do
     it "fetches the latest testflight build number" do
       expect(other_action).to receive(:latest_testflight_build_number).and_return(125)
-      expect(Fastlane::Helper::DdgAppleAutomationHelper.fetch_testflight_build_number(platform, options, other_action)).to eq(125)
+      expect(Fastlane::Helper::DdgAppleAutomationHelper.fetch_testflight_build_number(platform, options, nil, other_action)).to eq(125)
     end
   end
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210800422873798?focus=true 

Description:
This change updates `fetch_appcast_build_number` helper function to check
xcconfig file for Sparkle appcast URL. It also adds error handling to the HTTP GET
request.
Additionally, a new CalculateNextBuildNumberAction is added for use with alpha releases.
It’s still pending testing with the final workflow, but this addition isn't affecting existing workflows.

I have tested the changes locally in the monorepo.