### PR TITLE
Merge tag instead of release branch to main for internal releases

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
@@ -34,7 +34,7 @@ module Fastlane
         Helper::GitHubActionsHelper.set_output("tag", tag_and_release_output[:tag])
 
         begin
-          merge_or_delete_branch(params)
+          merge_or_delete_branch(params.values.merge(tag: tag_and_release_output[:tag]))
           tag_and_release_output[:merge_or_delete_successful] = true
         rescue StandardError
           tag_and_release_output[:merge_or_delete_successful] = false
@@ -99,10 +99,11 @@ module Fastlane
       end
 
       def self.merge_or_delete_branch(params)
-        branch = other_action.git_branch
         if params[:is_prerelease]
-          Helper::GitHelper.merge_branch(@constants[:repo_name], branch, params[:base_branch], params[:github_elevated_permissions_token] || params[:github_token])
+          # we actually merge the tag, not the branch
+          Helper::GitHelper.merge_branch(@constants[:repo_name], params[:tag], params[:base_branch], params[:github_elevated_permissions_token] || params[:github_token])
         else
+          branch = other_action.git_branch
           Helper::GitHelper.delete_branch(@constants[:repo_name], branch, params[:github_elevated_permissions_token] || params[:github_token])
         end
       end

--- a/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/internal-release-ready-merge-failed.html.erb
+++ b/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/internal-release-ready-merge-failed.html.erb
@@ -4,7 +4,7 @@
     <% if defined?(dmg_url) && !dmg_url.to_s.strip.empty? %><li>📥 DMG is available from <a href='<%= dmg_url %>'><%= dmg_url %></a>.</li><% end %>
     <li>🏷️ Repository is tagged with <code><%= tag %></code> tag.</li>
     <li>🚢 GitHub <a href='<%= release_url %>'><%= tag %> pre-release</a> is created.</li>
-    <li><b>❗️ Merging <code><%= branch %></code> to <code><%= base_branch %></code> failed.</b>
+    <li><b>❗️ Merging <code><%= tag %></code> tag to <code><%= base_branch %></code> failed.</b>
       <ul>
         <li><a data-asana-gid='<%= assignee_id %>' />, please proceed with manual merging <a data-asana-gid='<%= task_id %>'
             data-asana-dynamic='false'>according to instructions</a>.</li>

--- a/lib/fastlane/plugin/ddg_apple_automation/assets/asana_create_action_item/templates/merge-failed.yml.erb
+++ b/lib/fastlane/plugin/ddg_apple_automation/assets/asana_create_action_item/templates/merge-failed.yml.erb
@@ -1,21 +1,19 @@
-name: Merge <%= branch %> to <%= base_branch %>
+name: Merge <%= tag %> to <%= base_branch %>
 html_notes: |
   <body>
     The <code><%= tag %></code> release has been successfully tagged and published in GitHub releases, <%= '' %>
-    but merging to <code><%= base_branch %></code> failed. Please resolve conflicts and merge <code><%= branch %></code> to <code><%= base_branch %></code> manually.<br>
+    but merging to <code><%= base_branch %></code> failed. Please resolve conflicts and merge <code><%= tag %></code> tag to <code><%= base_branch %></code> manually.<br>
     <br>
     Issue the following git commands:
     <ul>
-      <li><code>git fetch origin</code></li>
-      <li><code>git checkout <%= branch %></code> switch to the release branch</li>
-      <li><code>git pull origin <%= branch %></code> pull latest changes</li>
+      <li><code>git fetch origin --tags</code></li>
       <li><code>git checkout <%= base_branch %></code> switch to <%= base_branch %></li>
       <li><code>git pull origin <%= base_branch %></code> pull the latest code</li>
-      <li><code>git merge <%= branch %></code>
+      <li><code>git merge <%= tag %></code>
         <ul>
           <li>Resolve conflicts as needed</li>
           <li>Run iOS, macOS and BSK unit and integration tests locally or create a separate branch and open a draft PR to let the CI handle it.</li>
-          <li>When merging a hotfix branch into an internal release branch, you will get conflicts in version and build number xcconfig files:
+          <li>When merging a hotfix tag into an internal release branch, you will get conflicts in version and build number xcconfig files:
             <ul>
               <li>In the version file: accept the internal version number (higher).</li>
               <li>In the build number file: accept the hotfix build number (higher). This step is very important in order to calculate the build number of the next internal release correctly.</li>

--- a/spec/asana_add_comment_action_spec.rb
+++ b/spec/asana_add_comment_action_spec.rb
@@ -232,7 +232,7 @@ describe Fastlane::Actions::AsanaAddCommentAction do
             <li>📥 DMG is available from <a href='https://cdn.com/bucket/duckduckgo-1.0.0.123.dmg'>https://cdn.com/bucket/duckduckgo-1.0.0.123.dmg</a>.</li>
             <li>🏷️ Repository is tagged with <code>1.0.0-123</code> tag.</li>
             <li>🚢 GitHub <a href='https://github.com/releases/tag/1.0.0-123'>1.0.0-123 pre-release</a> is created.</li>
-            <li><b>❗️ Merging <code>release/1.0.0</code> to <code>main</code> failed.</b>
+            <li><b>❗️ Merging <code>1.0.0-123</code> tag to <code>main</code> failed.</b>
               <ul>
                 <li><a data-asana-gid='12345' />, please proceed with manual merging <a data-asana-gid='67890'
                     data-asana-dynamic='false'>according to instructions</a>.</li>

--- a/spec/asana_create_action_item_action_spec.rb
+++ b/spec/asana_create_action_item_action_spec.rb
@@ -368,24 +368,22 @@ describe Fastlane::Actions::AsanaCreateActionItemAction do
     end
 
     it "processes merge-failed template" do
-      expected_name = "Merge release/1.0.0 to main"
+      expected_name = "Merge 1.0.0-123 to main"
       expected_notes = <<~EXPECTED
         <body>
           The <code>1.0.0-123</code> release has been successfully tagged and published in GitHub releases,#{' '}
-          but merging to <code>main</code> failed. Please resolve conflicts and merge <code>release/1.0.0</code> to <code>main</code> manually.<br>
+          but merging to <code>main</code> failed. Please resolve conflicts and merge <code>1.0.0-123</code> tag to <code>main</code> manually.<br>
           <br>
           Issue the following git commands:
           <ul>
-            <li><code>git fetch origin</code></li>
-            <li><code>git checkout release/1.0.0</code> switch to the release branch</li>
-            <li><code>git pull origin release/1.0.0</code> pull latest changes</li>
+            <li><code>git fetch origin --tags</code></li>
             <li><code>git checkout main</code> switch to main</li>
             <li><code>git pull origin main</code> pull the latest code</li>
-            <li><code>git merge release/1.0.0</code>
+            <li><code>git merge 1.0.0-123</code>
               <ul>
                 <li>Resolve conflicts as needed</li>
                 <li>Run iOS, macOS and BSK unit and integration tests locally or create a separate branch and open a draft PR to let the CI handle it.</li>
-                <li>When merging a hotfix branch into an internal release branch, you will get conflicts in version and build number xcconfig files:
+                <li>When merging a hotfix tag into an internal release branch, you will get conflicts in version and build number xcconfig files:
                   <ul>
                     <li>In the version file: accept the internal version number (higher).</li>
                     <li>In the build number file: accept the hotfix build number (higher). This step is very important in order to calculate the build number of the next internal release correctly.</li>

--- a/spec/tag_release_action_spec.rb
+++ b/spec/tag_release_action_spec.rb
@@ -84,7 +84,7 @@ describe Fastlane::Actions::TagReleaseAction do
       allow(Fastlane::Actions::TagReleaseAction).to receive(:report_status)
     end
 
-    it "creates tag and release, merges branch and reports status" do
+    it "creates tag and release, merges tag and reports status" do
       subject
 
       expect(@tag_and_release_output[:merge_or_delete_successful]).to be_truthy
@@ -281,6 +281,7 @@ describe Fastlane::Actions::TagReleaseAction do
 
     before do
       @params[:base_branch] = "base_branch"
+      @params[:tag] = "1.1.0-123+macos"
       allow(Fastlane::Action).to receive(:other_action).and_return(other_action)
       allow(Fastlane::Helper::GitHelper).to receive(:merge_branch)
       allow(Fastlane::Helper::GitHelper).to receive(:delete_branch)
@@ -293,19 +294,17 @@ describe Fastlane::Actions::TagReleaseAction do
         context "for prerelease" do
           include_context "for prerelease"
 
-          it "merges branch" do
+          it "merges tag to base branch" do
             subject
-            expect(other_action).to have_received(:git_branch)
             expect(Fastlane::Helper::GitHelper).to have_received(:merge_branch)
-              .with(platform_context[:repo_name], branch, @params[:base_branch], @params[:github_token])
+              .with(platform_context[:repo_name], @params[:tag], @params[:base_branch], @params[:github_token])
           end
 
           it "uses elevated permissions GitHub token if provided" do
             @params[:github_elevated_permissions_token] = "elevated-permissions-token"
             subject
-            expect(other_action).to have_received(:git_branch)
             expect(Fastlane::Helper::GitHelper).to have_received(:merge_branch)
-              .with(platform_context[:repo_name], branch, @params[:base_branch], @params[:github_elevated_permissions_token])
+              .with(platform_context[:repo_name], @params[:tag], @params[:base_branch], @params[:github_elevated_permissions_token])
           end
         end
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210994795858971

This change updates TagReleaseAction so that for internal releases it merges the freshly created tag to the base branch,
and not the release branch. This prevents from accidentally merging new unreleased commits added to the release branch
after the internal bump workflow had started.
The public release workflow works the same and it deletes the release branch.