### PR TITLE
Update release notes header for subscribers

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/helper/release_notes/asana_release_notes_extractor.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/release_notes/asana_release_notes_extractor.rb
@@ -8,7 +8,7 @@ module Fastlane
   module Helper
     class AsanaReleaseNotesExtractor
       START_MARKER = "release notes"
-      PP_MARKER = /^for privacy pro subscribers:?$/
+      PP_MARKER = /^for duckduckgo subscribers:?$/
       END_MARKER = "this release includes:"
       PLACEHOLDER = "add release notes here"
 
@@ -93,10 +93,10 @@ module Fastlane
         @is_capturing_pp = true
         case @output_type
         when "asana"
-          add_to_pp_notes("</ul><h2>For Privacy Pro subscribers</h2><ul>")
+          add_to_pp_notes("</ul><h2>For DuckDuckGo subscribers</h2><ul>")
         when "html"
           add_to_pp_notes("</ul>")
-          add_to_pp_notes("<h3 style=\"font-size:14px\">For Privacy Pro subscribers</h3>")
+          add_to_pp_notes("<h3 style=\"font-size:14px\">For DuckDuckGo subscribers</h3>")
           add_to_pp_notes("<ul>")
         else
           add_to_pp_notes(line.strip)

--- a/lib/fastlane/plugin/ddg_apple_automation/version.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module DdgAppleAutomation
-    VERSION = "2.10.0"
+    VERSION = "2.11.0"
   end
 end

--- a/spec/asana_release_notes_extractor_spec.rb
+++ b/spec/asana_release_notes_extractor_spec.rb
@@ -10,7 +10,7 @@ Release notes
 
   <-- Add release notes here -->
 
-For Privacy Pro subscribers
+For DuckDuckGo subscribers
 
   <-- Add release notes here -->
 
@@ -54,7 +54,7 @@ Release notes
   When watching videos in Duck Player, clicking endscreen recommendations will now open those videos in the same tab.
   The bug that duplicated sites in your browsing history has been fixed, and the visual glitching that sometimes occurred during session restore and app launch has been addressed.
 
-For Privacy Pro subscribers
+For DuckDuckGo subscribers
 
   VPN updates! More detailed connection info in the VPN dashboard, plus animations and usability improvements.
   Visit https://duckduckgo.com/pro for more information. Privacy Pro is currently available to U.S. residents only.
@@ -71,7 +71,7 @@ You can now find browser windows listed in the "Window" app menu and in the Dock
 We also added "Duplicate Tab" to the app menu so you can use it as an action in Apple Shortcuts.
 When watching videos in Duck Player, clicking endscreen recommendations will now open those videos in the same tab.
 The bug that duplicated sites in your browsing history has been fixed, and the visual glitching that sometimes occurred during session restore and app launch has been addressed.
-For Privacy Pro subscribers
+For DuckDuckGo subscribers
 VPN updates! More detailed connection info in the VPN dashboard, plus animations and usability improvements.
 Visit https://duckduckgo.com/pro for more information. Privacy Pro is currently available to U.S. residents only.
       RAW
@@ -84,7 +84,7 @@ Visit https://duckduckgo.com/pro for more information. Privacy Pro is currently 
 <li>When watching videos in Duck Player, clicking endscreen recommendations will now open those videos in the same tab.</li>
 <li>The bug that duplicated sites in your browsing history has been fixed, and the visual glitching that sometimes occurred during session restore and app launch has been addressed.</li>
 </ul>
-<h3 style="font-size:14px">For Privacy Pro subscribers</h3>
+<h3 style="font-size:14px">For DuckDuckGo subscribers</h3>
 <ul>
 <li>VPN updates! More detailed connection info in the VPN dashboard, plus animations and usability improvements.</li>
 <li>Visit <a href="https://duckduckgo.com/pro">https://duckduckgo.com/pro</a> for more information. Privacy Pro is currently available to U.S. residents only.</li>
@@ -92,7 +92,7 @@ Visit https://duckduckgo.com/pro for more information. Privacy Pro is currently 
       HTML
 
       asana = <<-ASANA
-<ul><li>You can now find browser windows listed in the &quot;Window&quot; app menu and in the Dock menu.</li><li>We also added &quot;Duplicate Tab&quot; to the app menu so you can use it as an action in Apple Shortcuts.</li><li>When watching videos in Duck Player, clicking endscreen recommendations will now open those videos in the same tab.</li><li>The bug that duplicated sites in your browsing history has been fixed, and the visual glitching that sometimes occurred during session restore and app launch has been addressed.</li></ul><h2>For Privacy Pro subscribers</h2><ul><li>VPN updates! More detailed connection info in the VPN dashboard, plus animations and usability improvements.</li><li>Visit <a href="https://duckduckgo.com/pro">https://duckduckgo.com/pro</a> for more information. Privacy Pro is currently available to U.S. residents only.</li></ul>
+<ul><li>You can now find browser windows listed in the &quot;Window&quot; app menu and in the Dock menu.</li><li>We also added &quot;Duplicate Tab&quot; to the app menu so you can use it as an action in Apple Shortcuts.</li><li>When watching videos in Duck Player, clicking endscreen recommendations will now open those videos in the same tab.</li><li>The bug that duplicated sites in your browsing history has been fixed, and the visual glitching that sometimes occurred during session restore and app launch has been addressed.</li></ul><h2>For DuckDuckGo subscribers</h2><ul><li>VPN updates! More detailed connection info in the VPN dashboard, plus animations and usability improvements.</li><li>Visit <a href="https://duckduckgo.com/pro">https://duckduckgo.com/pro</a> for more information. Privacy Pro is currently available to U.S. residents only.</li></ul>
       ASANA
 
       @output = {
@@ -167,7 +167,7 @@ Release notes
   When watching videos in Duck Player, clicking endscreen recommendations will now open those videos in the same tab.
   The bug that duplicated sites in your browsing history has been fixed, and the visual glitching that sometimes occurred during session restore and app launch has been addressed.
 
-For Privacy Pro subscribers
+For DuckDuckGo subscribers
 
   <-- Add release notes here -->
 
@@ -220,7 +220,7 @@ Release notes
   We also added "Duplicate Tab" to the app menu so you can use it as an action in Apple Shortcuts.
   When watching videos in Duck Player, clicking endscreen recommendations will now open those videos in the same tab.
   The bug that duplicated sites in your browsing history has been fixed, and the visual glitching that sometimes occurred during session restore and app launch has been addressed.
-  For Privacy Pro subscribers
+  For DuckDuckGo subscribers
   VPN updates! More detailed connection info in the VPN dashboard, plus animations and usability improvements.
   Visit https://duckduckgo.com/pro for more information. Privacy Pro is currently available to U.S. residents only.
 
@@ -236,7 +236,7 @@ You can now find browser windows listed in the "Window" app menu and in the Dock
 We also added "Duplicate Tab" to the app menu so you can use it as an action in Apple Shortcuts.
 When watching videos in Duck Player, clicking endscreen recommendations will now open those videos in the same tab.
 The bug that duplicated sites in your browsing history has been fixed, and the visual glitching that sometimes occurred during session restore and app launch has been addressed.
-For Privacy Pro subscribers
+For DuckDuckGo subscribers
 VPN updates! More detailed connection info in the VPN dashboard, plus animations and usability improvements.
 Visit https://duckduckgo.com/pro for more information. Privacy Pro is currently available to U.S. residents only.
       RAW
@@ -249,7 +249,7 @@ Visit https://duckduckgo.com/pro for more information. Privacy Pro is currently 
 <li>When watching videos in Duck Player, clicking endscreen recommendations will now open those videos in the same tab.</li>
 <li>The bug that duplicated sites in your browsing history has been fixed, and the visual glitching that sometimes occurred during session restore and app launch has been addressed.</li>
 </ul>
-<h3 style="font-size:14px">For Privacy Pro subscribers</h3>
+<h3 style="font-size:14px">For DuckDuckGo subscribers</h3>
 <ul>
 <li>VPN updates! More detailed connection info in the VPN dashboard, plus animations and usability improvements.</li>
 <li>Visit <a href="https://duckduckgo.com/pro">https://duckduckgo.com/pro</a> for more information. Privacy Pro is currently available to U.S. residents only.</li>
@@ -257,7 +257,7 @@ Visit https://duckduckgo.com/pro for more information. Privacy Pro is currently 
       HTML
 
       asana = <<-ASANA
-<ul><li>You can now find browser windows listed in the &quot;Window&quot; app menu and in the Dock menu.</li><li>We also added &quot;Duplicate Tab&quot; to the app menu so you can use it as an action in Apple Shortcuts.</li><li>When watching videos in Duck Player, clicking endscreen recommendations will now open those videos in the same tab.</li><li>The bug that duplicated sites in your browsing history has been fixed, and the visual glitching that sometimes occurred during session restore and app launch has been addressed.</li></ul><h2>For Privacy Pro subscribers</h2><ul><li>VPN updates! More detailed connection info in the VPN dashboard, plus animations and usability improvements.</li><li>Visit <a href="https://duckduckgo.com/pro">https://duckduckgo.com/pro</a> for more information. Privacy Pro is currently available to U.S. residents only.</li></ul>
+<ul><li>You can now find browser windows listed in the &quot;Window&quot; app menu and in the Dock menu.</li><li>We also added &quot;Duplicate Tab&quot; to the app menu so you can use it as an action in Apple Shortcuts.</li><li>When watching videos in Duck Player, clicking endscreen recommendations will now open those videos in the same tab.</li><li>The bug that duplicated sites in your browsing history has been fixed, and the visual glitching that sometimes occurred during session restore and app launch has been addressed.</li></ul><h2>For DuckDuckGo subscribers</h2><ul><li>VPN updates! More detailed connection info in the VPN dashboard, plus animations and usability improvements.</li><li>Visit <a href="https://duckduckgo.com/pro">https://duckduckgo.com/pro</a> for more information. Privacy Pro is currently available to U.S. residents only.</li></ul>
       ASANA
 
       @output = {


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1211082351847152?focus=true

Description:
This change updates release notes header for subscribers, replacing “Privacy Pro” with “DuckDuckGo”.