### PR TITLE
Add a comment to the hotfix task if the internal release bump is blocked

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
@@ -48,7 +48,10 @@ module Fastlane
         release_branch = Helper::DdgAppleAutomationHelper.release_branch_name(platform, latest_marketing_version)
         UI.success("Found #{latest_marketing_version} release task: #{release_task_url}")
 
-        report_hotfix_task_if_needed(hotfix_task_id, release_task_id, asana_access_token)
+        if hotfix_task_id
+          report_hotfix_task(hotfix_task_id, release_task_id, asana_access_token)
+          return
+        end
 
         Helper::GitHubActionsHelper.set_output("release_branch", release_branch)
         Helper::GitHubActionsHelper.set_output("release_task_id", release_task_id)
@@ -146,7 +149,7 @@ module Fastlane
         tasks.find { |task| task.name.start_with?(@constants[:hotfix_task_prefix]) }&.gid
       end
 
-      def self.report_hotfix_task_if_needed(hotfix_task_id, release_task_id, asana_access_token)
+      def self.report_hotfix_task(hotfix_task_id, release_task_id, asana_access_token)
         return unless hotfix_task_id
 
         hotfix_task_url = Helper::AsanaHelper.asana_task_url(hotfix_task_id)

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
@@ -153,16 +153,16 @@ module Fastlane
         return unless hotfix_task_id
 
         hotfix_task_url = Helper::AsanaHelper.asana_task_url(hotfix_task_id)
-        hotfix_task_assignee_id = Helper::AsanaHelper.extract_asana_task_assignee(hotfix_task_id, asana_access_token)
-        release_task_assignee_id = Helper::AsanaHelper.extract_asana_task_assignee(release_task_id, asana_access_token)
 
         begin
+          hotfix_task_assignee_id = Helper::AsanaHelper.extract_asana_task_assignee(hotfix_task_id, asana_access_token)
+          release_task_assignee_id = Helper::AsanaHelper.extract_asana_task_assignee(release_task_id, asana_access_token)
           asana_client = Helper::AsanaHelper.make_asana_client(asana_access_token)
           UI.important("Adding user #{release_task_assignee_id} as collaborator on hotfix release task #{hotfix_task_id}")
           asana_client.tasks.add_followers_for_task(task_gid: hotfix_task_id, followers: [release_task_assignee_id])
         rescue StandardError => e
           Helper::DdgAppleAutomationHelper.log_error(e)
-          UI.user_error!("Failed to add user #{release_task_assignee_id} as collaborator on task #{hotfix_task_id}")
+          UI.user_error!("Failed to add release task assignee as collaborator on task #{hotfix_task_id}")
           return
         end
 

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
@@ -142,7 +142,7 @@ module Fastlane
         hotfix_task_id = tasks.find { |task| task.name.start_with?(@constants[:hotfix_task_prefix]) }&.gid
 
         if hotfix_task_id
-          UI.user_error!("Found active hotfix task: #{Helper::AsanaHelper.asana_task_url(hotfix_task_id)}")
+          UI.error("Found active hotfix task: #{Helper::AsanaHelper.asana_task_url(hotfix_task_id)}")
           return
         end
       end

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
@@ -151,11 +151,13 @@ module Fastlane
 
         hotfix_task_url = Helper::AsanaHelper.asana_task_url(hotfix_task_id)
         hotfix_task_assignee_id = Helper::AsanaHelper.extract_asana_task_assignee(hotfix_task_id, asana_access_token)
+        release_task_assignee_id = Helper::AsanaHelper.extract_asana_task_assignee(release_task_id, asana_access_token)
         AsanaAddCommentAction.run(
           task_id: hotfix_task_id,
           template_name: 'hotfix-preventing-release-bump',
           template_args: {
             hotfix_task_assignee_id: hotfix_task_assignee_id,
+            release_task_assignee_id: release_task_assignee_id,
             release_task_id: release_task_id
           },
           asana_access_token: asana_access_token

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
@@ -154,6 +154,7 @@ module Fastlane
         release_task_assignee_id = Helper::AsanaHelper.extract_asana_task_assignee(release_task_id, asana_access_token)
 
         begin
+          asana_client = Helper::AsanaHelper.make_asana_client(asana_access_token)
           UI.important("Adding user #{release_task_assignee_id} as collaborator on hotfix release task #{hotfix_task_id}")
           asana_client.tasks.add_followers_for_task(task_gid: hotfix_task_id, followers: [release_task_assignee_id])
         rescue StandardError => e

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
@@ -152,6 +152,16 @@ module Fastlane
         hotfix_task_url = Helper::AsanaHelper.asana_task_url(hotfix_task_id)
         hotfix_task_assignee_id = Helper::AsanaHelper.extract_asana_task_assignee(hotfix_task_id, asana_access_token)
         release_task_assignee_id = Helper::AsanaHelper.extract_asana_task_assignee(release_task_id, asana_access_token)
+
+        begin
+          UI.important("Adding user #{release_task_assignee_id} as collaborator on hotfix release task #{hotfix_task_id}")
+          asana_client.tasks.add_followers_for_task(task_gid: hotfix_task_id, followers: [release_task_assignee_id])
+        rescue StandardError => e
+          Helper::DdgAppleAutomationHelper.log_error(e)
+          UI.user_error!("Failed to add user #{release_task_assignee_id} as collaborator on task #{hotfix_task_id}")
+          return
+        end
+
         AsanaAddCommentAction.run(
           task_id: hotfix_task_id,
           template_name: 'hotfix-preventing-release-bump',

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
@@ -177,7 +177,6 @@ module Fastlane
           asana_access_token: asana_access_token
         )
         UI.user_error!("Found active hotfix task: #{hotfix_task_url}")
-        return
       end
 
       def self.description

--- a/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/hotfix-preventing-release-bump.html.erb
+++ b/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/hotfix-preventing-release-bump.html.erb
@@ -1,0 +1,9 @@
+<body>
+  <a data-asana-gid='<%= hotfix_task_assignee_id %>' />, this hotfix task is preventing an automated internal release bump for <a data-asana-gid='<%= release_task_id %>' />.
+  <ul>
+    <li>If the hotfix release is still in progress, please ignore this comment.</li>
+    <li>If the hotfix release is complete, please close this task and re-run the internal release workflow.</li>
+  </ul>
+  <br>
+  🔗 Workflow URL: <a href='<%= workflow_url %>'><%= workflow_url %></a>.
+</body>

--- a/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/hotfix-preventing-release-bump.html.erb
+++ b/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/hotfix-preventing-release-bump.html.erb
@@ -3,7 +3,7 @@
   <ul>
     <li>If the hotfix release is still in progress, please ignore this comment.</li>
     <li>If the hotfix release is complete, please close this task and re-run the internal release workflow.</li>
-  </ul>
-  <br>
+  </ul><br>
+  cc <a data-asana-gid='<%= release_task_assignee_id %>' /><br>
   🔗 Workflow URL: <a href='<%= workflow_url %>'><%= workflow_url %></a>.
 </body>

--- a/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/hotfix-preventing-release-bump.html.erb
+++ b/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/hotfix-preventing-release-bump.html.erb
@@ -2,8 +2,9 @@
   <a data-asana-gid='<%= hotfix_task_assignee_id %>' />, this hotfix task is preventing an automated internal release bump for <a data-asana-gid='<%= release_task_id %>' />.
   <ul>
     <li>If the hotfix release is still in progress, please ignore this comment.</li>
-    <li>If the hotfix release is complete, please close this task and re-run the internal release workflow.</li>
+    <li>If the hotfix release is complete, please close this task and re-run the <a href='<%= workflow_url %>'>internal release workflow</a>.</li>
   </ul>
   cc <a data-asana-gid='<%= release_task_assignee_id %>' /><br>
+  <br>
   🔗 Workflow URL: <a href='<%= workflow_url %>'><%= workflow_url %></a>.
 </body>

--- a/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/hotfix-preventing-release-bump.html.erb
+++ b/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/hotfix-preventing-release-bump.html.erb
@@ -3,7 +3,7 @@
   <ul>
     <li>If the hotfix release is still in progress, please ignore this comment.</li>
     <li>If the hotfix release is complete, please close this task and re-run the internal release workflow.</li>
-  </ul><br>
+  </ul>
   cc <a data-asana-gid='<%= release_task_assignee_id %>' /><br>
   🔗 Workflow URL: <a href='<%= workflow_url %>'><%= workflow_url %></a>.
 </body>

--- a/spec/asana_add_comment_action_spec.rb
+++ b/spec/asana_add_comment_action_spec.rb
@@ -191,6 +191,28 @@ describe Fastlane::Actions::AsanaAddCommentAction do
       })).to eq(expected.chomp)
     end
 
+    it "processes hotfix-preventing-release-bump template" do
+      expected = <<~EXPECTED
+        <body>
+          <a data-asana-gid='12345' />, this hotfix task is preventing an automated internal release bump for <a data-asana-gid='1234567890' />.
+          <ul>
+            <li>If the hotfix release is still in progress, please ignore this comment.</li>
+            <li>If the hotfix release is complete, please close this task and re-run the <a href='https://workflow.com'>internal release workflow</a>.</li>
+          </ul>
+          cc <a data-asana-gid='67890' /><br>
+          <br>
+          🔗 Workflow URL: <a href='https://workflow.com'>https://workflow.com</a>.
+        </body>
+      EXPECTED
+
+      expect(process_template("hotfix-preventing-release-bump", {
+        "hotfix_task_assignee_id" => "12345",
+        "release_task_assignee_id" => "67890",
+        "release_task_id" => "1234567890",
+        "workflow_url" => "https://workflow.com"
+      })).to eq(expected.chomp)
+    end
+
     it "processes internal-release-complete-with-tasks template" do
       expected = <<~EXPECTED
         <body>

--- a/spec/asana_find_release_task_action_spec.rb
+++ b/spec/asana_find_release_task_action_spec.rb
@@ -279,9 +279,9 @@ describe Fastlane::Actions::AsanaFindReleaseTaskAction do
           @tasks = [double(name: 'iOS App Hotfix Release 1.0.0', gid: '1234567890')]
         end
         it "shows error" do
-          allow(Fastlane::UI).to receive(:user_error!)
+          allow(Fastlane::UI).to receive(:error)
           find_hotfix_task_in_response(@tasks)
-          expect(Fastlane::UI).to have_received(:user_error!).with("Found active hotfix task: https://app.asana.com/0/0/1234567890/f")
+          expect(Fastlane::UI).to have_received(:error).with("Found active hotfix task: https://app.asana.com/0/0/1234567890/f")
         end
       end
 
@@ -315,9 +315,9 @@ describe Fastlane::Actions::AsanaFindReleaseTaskAction do
         end
 
         it "shows error" do
-          allow(Fastlane::UI).to receive(:user_error!)
+          allow(Fastlane::UI).to receive(:error)
           find_hotfix_task_in_response(@tasks)
-          expect(Fastlane::UI).to have_received(:user_error!).with("Found active hotfix task: https://app.asana.com/0/0/1234567890/f")
+          expect(Fastlane::UI).to have_received(:error).with("Found active hotfix task: https://app.asana.com/0/0/1234567890/f")
         end
       end
 

--- a/spec/asana_find_release_task_action_spec.rb
+++ b/spec/asana_find_release_task_action_spec.rb
@@ -143,7 +143,7 @@ describe Fastlane::Actions::AsanaFindReleaseTaskAction do
           expect(Fastlane::Actions::AsanaFindReleaseTaskAction).to receive(:find_hotfix_task_in_response)
           expect(Fastlane::Actions::AsanaFindReleaseTaskAction).to receive(:find_release_task_in_response).and_return("1234567890")
 
-          expect(find_release_task("1.0.0")).to eq("1234567890")
+          expect(find_release_task("1.0.0")).to eq(["1234567890", nil])
         end
       end
 
@@ -157,7 +157,7 @@ describe Fastlane::Actions::AsanaFindReleaseTaskAction do
 
         it "returns the release task ID" do
           allow(Fastlane::Actions::AsanaFindReleaseTaskAction).to receive(:find_hotfix_task_in_response)
-          expect(find_release_task("1.0.0")).to eq("1234567890")
+          expect(find_release_task("1.0.0")).to eq(["1234567890", nil])
           expect(Fastlane::Actions::AsanaFindReleaseTaskAction).to have_received(:find_hotfix_task_in_response).twice
         end
       end
@@ -269,6 +269,8 @@ describe Fastlane::Actions::AsanaFindReleaseTaskAction do
   end
 
   describe "#find_hotfix_task_in_response" do
+    subject { Fastlane::Actions::AsanaFindReleaseTaskAction.find_hotfix_task_in_response(@tasks) }
+
     describe "on iOS" do
       before do
         Fastlane::Actions::AsanaFindReleaseTaskAction.setup_constants("ios")
@@ -278,28 +280,18 @@ describe Fastlane::Actions::AsanaFindReleaseTaskAction do
         before do
           @tasks = [double(name: 'iOS App Hotfix Release 1.0.0', gid: '1234567890')]
         end
-        it "shows error" do
-          allow(Fastlane::UI).to receive(:error)
-          find_hotfix_task_in_response(@tasks)
-          expect(Fastlane::UI).to have_received(:error).with("Found active hotfix task: https://app.asana.com/0/0/1234567890/f")
+        it "returns the hotfix task ID" do
+          expect(subject).to eq("1234567890")
         end
       end
 
       describe "when hotfix task is not present" do
         before do
-          @tasks_lists = [
-            [double(name: 'iOS App Release 1.0.0', gid: '1234567890')],
-            [double(name: 'iOS App Hotfix 1.0.0', gid: '123456789')],
-            [double(name: 'macOS App Hotfix 1.0.0', gid: '12345678')]
-          ]
+          @tasks = [double(name: 'iOS App Release 1.0.0', gid: '1234567890')]
         end
-        it "does not show error" do
-          allow(Fastlane::UI).to receive(:user_error!)
 
-          @tasks_lists.each do |tasks|
-            find_hotfix_task_in_response(tasks)
-          end
-          expect(Fastlane::UI).not_to have_received(:user_error!)
+        it "returns nil" do
+          expect(subject).to be_nil
         end
       end
     end
@@ -314,34 +306,20 @@ describe Fastlane::Actions::AsanaFindReleaseTaskAction do
           @tasks = [double(name: 'macOS App Hotfix Release 1.0.0', gid: '1234567890')]
         end
 
-        it "shows error" do
-          allow(Fastlane::UI).to receive(:error)
-          find_hotfix_task_in_response(@tasks)
-          expect(Fastlane::UI).to have_received(:error).with("Found active hotfix task: https://app.asana.com/0/0/1234567890/f")
+        it "returns the hotfix task ID" do
+          expect(subject).to eq("1234567890")
         end
       end
 
       describe "when hotfix task is not present" do
         before do
-          @tasks_lists = [
-            [double(name: 'macOS App Release 1.0.0', gid: '1234567890')],
-            [double(name: 'macOS App Hotfix 1.0.0', gid: '123456789')],
-            [double(name: 'iOS App Hotfix 1.0.0', gid: '12345678')]
-          ]
+          @tasks = [double(name: 'macOS App Release 1.0.0', gid: '1234567890')]
         end
-        it "does not show error" do
-          allow(Fastlane::UI).to receive(:user_error!)
 
-          @tasks_lists.each do |tasks|
-            find_hotfix_task_in_response(tasks)
-          end
-          expect(Fastlane::UI).not_to have_received(:user_error!)
+        it "returns nil" do
+          expect(subject).to be_nil
         end
       end
-    end
-
-    def find_hotfix_task_in_response(response)
-      Fastlane::Actions::AsanaFindReleaseTaskAction.find_hotfix_task_in_response(response)
     end
   end
 end


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1210994795858968?focus=true

This change updates AsanaFindReleaseTaskAction to post a comment to the hotfix task if found.
It also adds release DRI as collaborator to the hotfix task for visibility.