### PR TITLE
Add support for release branch freezing and unfreezing

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/asana_find_release_task_action.rb
@@ -38,7 +38,7 @@ module Fastlane
         setup_constants(platform)
 
         UI.message("Checking latest marketing version")
-        latest_marketing_version = find_latest_marketing_version(github_token, params[:platform])
+        latest_marketing_version = Helper::GitHelper.find_latest_marketing_version(github_token, params[:platform])
         UI.success("Latest marketing version: #{latest_marketing_version}")
         UI.message("Searching for release task for version #{latest_marketing_version}")
         release_task_id, hotfix_task_id = find_release_task(latest_marketing_version, asana_access_token)
@@ -62,31 +62,6 @@ module Fastlane
           release_task_url: release_task_url,
           release_branch: release_branch
         }
-      end
-
-      def self.find_latest_marketing_version(github_token, platform)
-        latest_internal_release = Helper::GitHelper.latest_release(Helper::GitHelper.repo_name, true, platform, github_token)
-
-        version = extract_version_from_tag_name(latest_internal_release&.tag_name)
-        if version.to_s.empty?
-          Fastlane::UI.user_error!("Failed to find latest marketing version")
-          return
-        end
-        unless self.validate_semver(version)
-          Fastlane::UI.user_error!("Invalid marketing version: #{version}, expected format: MAJOR.MINOR.PATCH")
-          return
-        end
-        version
-      end
-
-      def self.extract_version_from_tag_name(tag_name)
-        # Remove build number (if present) and platform suffix from the tag name
-        tag_name&.split(/[-+]/)&.first
-      end
-
-      def self.validate_semver(version)
-        # we only need basic "x.y.z" validation here
-        version.match?(/\A\d+\.\d+\.\d+\z/)
       end
 
       def self.find_release_task(version, asana_access_token)

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/asana_report_failed_workflow_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/asana_report_failed_workflow_action.rb
@@ -18,9 +18,11 @@ module Fastlane
 
         extra_collaborators = []
 
-        if params[:commit_sha]
-          args[:last_commit_url] = "https://github.com/#{Helper::GitHelper.repo_name}/commit/#{params[:commit_sha]}"
-          commit_author = Helper::GitHelper.commit_author(Helper::GitHelper.repo_name, params[:commit_sha], params[:github_token])
+        commit_sha = params[:commit_sha].to_s.strip
+
+        unless commit_sha.empty?
+          args[:last_commit_url] = "https://github.com/#{Helper::GitHelper.repo_name}/commit/#{commit_sha}"
+          commit_author = Helper::GitHelper.commit_author(Helper::GitHelper.repo_name, commit_sha, params[:github_token])
           args[:last_commit_author_id] = Helper::AsanaHelper.get_asana_user_id_for_github_handle(commit_author)
           extra_collaborators << args[:last_commit_author_id]
         end

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/freeze_release_branch_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/freeze_release_branch_action.rb
@@ -1,0 +1,79 @@
+require "fastlane/action"
+require "fastlane_core/configuration/config_item"
+require "octokit"
+require_relative "../helper/ddg_apple_automation_helper"
+require_relative "../helper/git_helper"
+
+module Fastlane
+  module Actions
+    class FreezeReleaseBranchAction < Action
+      def self.run(params)
+        github_token = params[:github_token]
+        platform = params[:platform] || Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
+
+        UI.message("Checking latest marketing version")
+        latest_marketing_version = Helper::GitHelper.find_latest_marketing_version(github_token, params[:platform])
+        UI.success("Latest marketing version: #{latest_marketing_version}")
+
+        draft_public_release_name = "#{latest_marketing_version}+#{platform}"
+
+        UI.message("Will freeze release branch for #{latest_marketing_version} by creating a draft public release")
+        UI.message("First we'll check if #{draft_public_release_name} release exists.")
+
+        UI.message("Checking for draft public release #{draft_public_release_name}")
+        latest_public_release = Helper::GitHelper.latest_release(Helper::GitHelper.repo_name, false, platform, github_token, allow_drafts: true)
+        UI.success("Latest public release (including drafts): #{latest_public_release.name}")
+
+        if latest_public_release.name == draft_public_release_name
+          UI.success("Draft public release #{draft_public_release_name} already exists. Nothing to do as the branch is already frozen.")
+          return
+        end
+
+        UI.message("Creating draft public release #{draft_public_release_name}")
+
+        begin
+          other_action.set_github_release(
+            repository_name: Helper::GitHelper.repo_name,
+            api_bearer: github_token,
+            name: draft_public_release_name,
+            tag_name: "",
+            is_draft: true,
+            is_prerelease: false
+          )
+          UI.success("Draft public release #{draft_public_release_name} created")
+        rescue StandardError => e
+          UI.important("Failed to create GitHub release")
+          Helper::DdgAppleAutomationHelper.report_error(e)
+        end
+      end
+
+      def self.description
+        "Adds a draft public release for the latest marketing version as an indicator of a frozen release branch"
+      end
+
+      def self.authors
+        ["DuckDuckGo"]
+      end
+
+      def self.return_value
+        ""
+      end
+
+      def self.details
+        "This action checks the latest marketing version in GitHub and creates a draft public release for it.
+        If the release already exists, it does nothing."
+      end
+
+      def self.available_options
+        [
+          FastlaneCore::ConfigItem.github_token,
+          FastlaneCore::ConfigItem.platform
+        ]
+      end
+
+      def self.is_supported?(platform)
+        true
+      end
+    end
+  end
+end

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/freeze_release_branch_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/freeze_release_branch_action.rb
@@ -11,39 +11,8 @@ module Fastlane
         github_token = params[:github_token]
         platform = params[:platform] || Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
 
-        UI.message("Checking latest marketing version")
-        latest_marketing_version = Helper::GitHelper.find_latest_marketing_version(github_token, params[:platform])
-        UI.success("Latest marketing version: #{latest_marketing_version}")
-
-        draft_public_release_name = "#{latest_marketing_version}+#{platform}"
-
-        UI.message("Will freeze release branch for #{latest_marketing_version} by creating a draft public release")
-        UI.message("First we'll check if #{draft_public_release_name} release exists.")
-
-        UI.message("Checking for draft public release #{draft_public_release_name}")
-        latest_public_release = Helper::GitHelper.latest_release(Helper::GitHelper.repo_name, false, platform, github_token, allow_drafts: true)
-        UI.success("Latest public release (including drafts): #{latest_public_release.name}")
-
-        if latest_public_release.name == draft_public_release_name
-          UI.success("Draft public release #{draft_public_release_name} already exists. Nothing to do as the branch is already frozen.")
-          return
-        end
-
-        UI.message("Creating draft public release #{draft_public_release_name}")
-
         begin
-          other_action.set_github_release(
-            repository_name: Helper::GitHelper.repo_name,
-            api_bearer: github_token,
-            description: "This draft release is here to indicate that the release branch is frozen.
-            New internal releases on `release/#{platform}/#{latest_marketing_version}` branch cannot be created.
-            If you need to bump the internal release, please manually delete this draft release.",
-            name: draft_public_release_name,
-            tag_name: "",
-            is_draft: true,
-            is_prerelease: false
-          )
-          UI.success("Draft public release #{draft_public_release_name} created")
+          Helper::GitHelper.freeze_release_branch(platform, github_token, other_action)
         rescue StandardError => e
           UI.important("Failed to create GitHub release")
           Helper::DdgAppleAutomationHelper.report_error(e)

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/freeze_release_branch_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/freeze_release_branch_action.rb
@@ -35,6 +35,9 @@ module Fastlane
           other_action.set_github_release(
             repository_name: Helper::GitHelper.repo_name,
             api_bearer: github_token,
+            description: "This draft release is here to indicate that the release branch is frozen.
+            New internal releases on `release/#{platform}/#{latest_marketing_version}` branch cannot be created.
+            If you need to bump the internal release, please manually delete this draft release.",
             name: draft_public_release_name,
             tag_name: "",
             is_draft: true,

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/freeze_release_branch_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/freeze_release_branch_action.rb
@@ -8,11 +8,10 @@ module Fastlane
   module Actions
     class FreezeReleaseBranchAction < Action
       def self.run(params)
-        github_token = params[:github_token]
         platform = params[:platform] || Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
 
         begin
-          Helper::GitHelper.freeze_release_branch(platform, github_token, other_action)
+          Helper::GitHelper.freeze_release_branch(platform, params[:github_token], other_action)
         rescue StandardError => e
           UI.important("Failed to create GitHub release")
           Helper::DdgAppleAutomationHelper.report_error(e)

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
@@ -34,10 +34,7 @@ module Fastlane
           begin
             Helper::GitHelper.unfreeze_release_branch(branch, platform, params[:github_token])
           rescue StandardError => e
-            task_id = AsanaExtractTaskIdAction.run(
-              asana_access_token: params[:asana_access_token],
-              asana_task_url: params[:asana_task_url]
-            )[:task_id]
+            task_id = AsanaExtractTaskIdAction.run(task_url: params[:asana_task_url])
             AsanaReportFailedWorkflowAction.run(
               task_id: task_id,
               branch: branch,

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
@@ -23,6 +23,7 @@ module Fastlane
         end
       end
 
+      # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         platform = params[:platform] || Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
         Helper::GitHelper.setup_git_user
@@ -35,6 +36,8 @@ module Fastlane
             Helper::GitHelper.unfreeze_release_branch(branch, platform, params[:github_token])
           rescue StandardError => e
             Helper::GitHubActionsHelper.set_output("stop_workflow", true)
+            Helper::DdgAppleAutomationHelper.report_error(e)
+            UI.important("Failed to unfreeze release branch. Cannot proceed with the public release. Please unfreeze manually and run the workflow again.")
             task_id = AsanaExtractTaskIdAction.run(task_url: params[:asana_task_url])
             AsanaReportFailedWorkflowAction.run(
               asana_access_token: params[:asana_access_token],
@@ -46,8 +49,6 @@ module Fastlane
               workflow_name: "Tag Release",
               workflow_url: ENV.fetch("WORKFLOW_URL", nil)
             )
-            UI.important("Failed to unfreeze release branch. Cannot proceed with the public release. Please unfreeze manually and run the workflow again.")
-            Helper::DdgAppleAutomationHelper.report_error(e)
             return
           end
         end
@@ -58,35 +59,35 @@ module Fastlane
           return
         end
 
-        # if should_merge_before_deleting(params)
-        #   begin
-        #     branch = other_action.git_branch
-        #     # merge the branch (not the tag) to the base branch first to have untagged commits in the base branch
-        #     UI.important("Merging branch before deleting to have untagged commits in the base branch")
-        #     Helper::GitHelper.merge_branch(@constants[:repo_name], branch, params[:base_branch], params[:github_elevated_permissions_token] || params[:github_token])
-        #   rescue StandardError => e
-        #     report_merge_release_branch_before_deleting_failed(params.values.merge(branch: branch))
-        #     UI.important("Merging release branch to base branch failed. Cannot proceed with the public release. Please merge manually and run the workflow again.")
-        #     Helper::GitHubActionsHelper.set_output("stop_workflow", true)
-        #     Helper::DdgAppleAutomationHelper.report_error(e)
-        #     return
-        #   end
-        # end
+        if should_merge_before_deleting(params)
+          begin
+            branch = other_action.git_branch
+            # merge the branch (not the tag) to the base branch first to have untagged commits in the base branch
+            UI.important("Merging branch before deleting to have untagged commits in the base branch")
+            Helper::GitHelper.merge_branch(@constants[:repo_name], branch, params[:base_branch], params[:github_elevated_permissions_token] || params[:github_token])
+          rescue StandardError => e
+            report_merge_release_branch_before_deleting_failed(params.values.merge(branch: branch))
+            UI.important("Merging release branch to base branch failed. Cannot proceed with the public release. Please merge manually and run the workflow again.")
+            Helper::GitHubActionsHelper.set_output("stop_workflow", true)
+            Helper::DdgAppleAutomationHelper.report_error(e)
+            return
+          end
+        end
 
-        # tag_and_release_output = create_tag_and_github_release(params[:is_prerelease], platform, params[:github_token])
-        # Helper::GitHubActionsHelper.set_output("tag", tag_and_release_output[:tag])
+        tag_and_release_output = create_tag_and_github_release(params[:is_prerelease], platform, params[:github_token])
+        Helper::GitHubActionsHelper.set_output("tag", tag_and_release_output[:tag])
 
-        # if tag_and_release_output[:tag_created]
-        #   begin
-        #     merge_or_delete_branch(params.values.merge(tag: tag_and_release_output[:tag]))
-        #     tag_and_release_output[:merge_or_delete_successful] = true
-        #   rescue StandardError => e
-        #     tag_and_release_output[:merge_or_delete_successful] = false
-        #     Helper::DdgAppleAutomationHelper.report_error(e)
-        #   end
-        # end
+        if tag_and_release_output[:tag_created]
+          begin
+            merge_or_delete_branch(params.values.merge(tag: tag_and_release_output[:tag]))
+            tag_and_release_output[:merge_or_delete_successful] = true
+          rescue StandardError => e
+            tag_and_release_output[:merge_or_delete_successful] = false
+            Helper::DdgAppleAutomationHelper.report_error(e)
+          end
+        end
 
-        # report_status(params.values.merge(tag_and_release_output))
+        report_status(params.values.merge(tag_and_release_output))
       end
 
       def self.should_merge_before_deleting(params)
@@ -109,6 +110,7 @@ module Fastlane
         end
         true
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       def self.create_tag_and_github_release(is_prerelease, platform, github_token)
         tag, promoted_tag = Helper::DdgAppleAutomationHelper.compute_tag(is_prerelease, platform)

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
@@ -52,13 +52,11 @@ module Fastlane
           end
         end
 
-        UI.success("Success ✅💪")
-
-        # unless assert_branch_tagged_before_public_release(params.values)
-        #   UI.important("Skipping release because release branch's HEAD is not tagged.")
-        #   Helper::GitHubActionsHelper.set_output("stop_workflow", true)
-        #   return
-        # end
+        unless assert_branch_tagged_before_public_release(params.values)
+          UI.important("Skipping release because release branch's HEAD is not tagged.")
+          Helper::GitHubActionsHelper.set_output("stop_workflow", true)
+          return
+        end
 
         # if should_merge_before_deleting(params)
         #   begin

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
@@ -23,7 +23,6 @@ module Fastlane
         end
       end
 
-      # rubocop:disable Metrics/PerceivedComplexity
       def self.run(params)
         platform = params[:platform] || Actions.lane_context[Actions::SharedValues::PLATFORM_NAME]
         Helper::GitHelper.setup_git_user
@@ -53,43 +52,44 @@ module Fastlane
           end
         end
 
-        unless assert_branch_tagged_before_public_release(params.values)
-          UI.important("Skipping release because release branch's HEAD is not tagged.")
-          Helper::GitHubActionsHelper.set_output("stop_workflow", true)
-          return
-        end
+        UI.success("Success ✅💪")
 
-        if should_merge_before_deleting(params)
-          begin
-            branch = other_action.git_branch
-            # merge the branch (not the tag) to the base branch first to have untagged commits in the base branch
-            UI.important("Merging branch before deleting to have untagged commits in the base branch")
-            Helper::GitHelper.merge_branch(@constants[:repo_name], branch, params[:base_branch], params[:github_elevated_permissions_token] || params[:github_token])
-          rescue StandardError => e
-            report_merge_release_branch_before_deleting_failed(params.values.merge(branch: branch))
-            UI.important("Merging release branch to base branch failed. Cannot proceed with the public release. Please merge manually and run the workflow again.")
-            Helper::GitHubActionsHelper.set_output("stop_workflow", true)
-            Helper::DdgAppleAutomationHelper.report_error(e)
-            return
-          end
-        end
+        # unless assert_branch_tagged_before_public_release(params.values)
+        #   UI.important("Skipping release because release branch's HEAD is not tagged.")
+        #   Helper::GitHubActionsHelper.set_output("stop_workflow", true)
+        #   return
+        # end
 
-        tag_and_release_output = create_tag_and_github_release(params[:is_prerelease], platform, params[:github_token])
-        Helper::GitHubActionsHelper.set_output("tag", tag_and_release_output[:tag])
+        # if should_merge_before_deleting(params)
+        #   begin
+        #     branch = other_action.git_branch
+        #     # merge the branch (not the tag) to the base branch first to have untagged commits in the base branch
+        #     UI.important("Merging branch before deleting to have untagged commits in the base branch")
+        #     Helper::GitHelper.merge_branch(@constants[:repo_name], branch, params[:base_branch], params[:github_elevated_permissions_token] || params[:github_token])
+        #   rescue StandardError => e
+        #     report_merge_release_branch_before_deleting_failed(params.values.merge(branch: branch))
+        #     UI.important("Merging release branch to base branch failed. Cannot proceed with the public release. Please merge manually and run the workflow again.")
+        #     Helper::GitHubActionsHelper.set_output("stop_workflow", true)
+        #     Helper::DdgAppleAutomationHelper.report_error(e)
+        #     return
+        #   end
+        # end
 
-        if tag_and_release_output[:tag_created]
-          begin
-            merge_or_delete_branch(params.values.merge(tag: tag_and_release_output[:tag]))
-            tag_and_release_output[:merge_or_delete_successful] = true
-          rescue StandardError => e
-            tag_and_release_output[:merge_or_delete_successful] = false
-            Helper::DdgAppleAutomationHelper.report_error(e)
-          end
-        end
+        # tag_and_release_output = create_tag_and_github_release(params[:is_prerelease], platform, params[:github_token])
+        # Helper::GitHubActionsHelper.set_output("tag", tag_and_release_output[:tag])
 
-        report_status(params.values.merge(tag_and_release_output))
+        # if tag_and_release_output[:tag_created]
+        #   begin
+        #     merge_or_delete_branch(params.values.merge(tag: tag_and_release_output[:tag]))
+        #     tag_and_release_output[:merge_or_delete_successful] = true
+        #   rescue StandardError => e
+        #     tag_and_release_output[:merge_or_delete_successful] = false
+        #     Helper::DdgAppleAutomationHelper.report_error(e)
+        #   end
+        # end
+
+        # report_status(params.values.merge(tag_and_release_output))
       end
-      # rubocop:enable Metrics/PerceivedComplexity
 
       def self.should_merge_before_deleting(params)
         # Only merge before deleting for public releases and if ignore_untagged_commits is true

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/tag_release_action.rb
@@ -34,8 +34,12 @@ module Fastlane
           begin
             Helper::GitHelper.unfreeze_release_branch(branch, platform, params[:github_token])
           rescue StandardError => e
+            Helper::GitHubActionsHelper.set_output("stop_workflow", true)
             task_id = AsanaExtractTaskIdAction.run(task_url: params[:asana_task_url])
             AsanaReportFailedWorkflowAction.run(
+              asana_access_token: params[:asana_access_token],
+              github_token: params[:github_token],
+              platform: platform,
               task_id: task_id,
               branch: branch,
               github_handle: params[:github_handle],
@@ -43,7 +47,6 @@ module Fastlane
               workflow_url: ENV.fetch("WORKFLOW_URL", nil)
             )
             UI.important("Failed to unfreeze release branch. Cannot proceed with the public release. Please unfreeze manually and run the workflow again.")
-            Helper::GitHubActionsHelper.set_output("stop_workflow", true)
             Helper::DdgAppleAutomationHelper.report_error(e)
             return
           end

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/validate_internal_release_bump_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/validate_internal_release_bump_action.rb
@@ -15,7 +15,7 @@ module Fastlane
         options = params.values
         find_release_task_if_needed(options)
 
-        Helper::GitHelper.assert_release_branch_is_not_frozen!(options[:release_branch], params[:platform], options[:github_token])
+        Helper::GitHelper.assert_release_branch_is_not_frozen(options[:release_branch], params[:platform], options[:github_token])
 
         if params[:is_scheduled_release] && !Helper::GitHelper.assert_branch_has_changes(options[:release_branch], params[:platform])
           UI.important("No changes to the release branch (or only changes to scripts and workflows). Skipping automatic release.")

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/validate_internal_release_bump_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/validate_internal_release_bump_action.rb
@@ -1,6 +1,7 @@
 require "fastlane/action"
 require "fastlane_core/configuration/config_item"
 require_relative "asana_find_release_task_action"
+require_relative "asana_add_comment_action"
 require_relative "../helper/asana_helper"
 require_relative "../helper/git_helper"
 
@@ -13,6 +14,8 @@ module Fastlane
 
         options = params.values
         find_release_task_if_needed(options)
+
+        Helper::GitHelper.assert_release_branch_is_not_frozen!(options[:release_branch], params[:platform], options[:github_token])
 
         if params[:is_scheduled_release] && !Helper::GitHelper.assert_branch_has_changes(options[:release_branch], params[:platform])
           UI.important("No changes to the release branch (or only changes to scripts and workflows). Skipping automatic release.")

--- a/lib/fastlane/plugin/ddg_apple_automation/actions/validate_internal_release_bump_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/validate_internal_release_bump_action.rb
@@ -1,7 +1,6 @@
 require "fastlane/action"
 require "fastlane_core/configuration/config_item"
 require_relative "asana_find_release_task_action"
-require_relative "asana_add_comment_action"
 require_relative "../helper/asana_helper"
 require_relative "../helper/git_helper"
 

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/git_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/git_helper.rb
@@ -192,7 +192,7 @@ module Fastlane
         UI.success("Draft public release #{draft_public_release_name} created")
       end
 
-      def self.assert_release_branch_is_not_frozen!(release_branch, platform, github_token)
+      def self.assert_release_branch_is_not_frozen(release_branch, platform, github_token)
         UI.message("Checking if release on #{release_branch} branch can be bumped.")
 
         marketing_version = extract_version_from_branch_name(release_branch)

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/git_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/git_helper.rb
@@ -90,7 +90,8 @@ module Fastlane
         `git rev-parse "#{tag}"^{}`.chomp
       end
 
-      def self.latest_release(repo_name, prerelease, platform, github_token)
+      # rubocop:disable Metrics/PerceivedComplexity
+      def self.latest_release(repo_name, prerelease, platform, github_token, allow_drafts: false)
         client = Octokit::Client.new(access_token: github_token)
 
         current_page = 1
@@ -104,6 +105,9 @@ module Fastlane
           # If `prerelease` is false, then ensure that the release is public.
           matching_release = releases.find do |release|
             matches_platform = platform.nil? || release.tag_name.end_with?("+#{platform}")
+            if allow_drafts
+              matches_platform ||= release.name.end_with?("+#{platform}")
+            end
             matches_prerelease = prerelease == release.prerelease
             matches_platform && matches_prerelease
           end
@@ -116,6 +120,7 @@ module Fastlane
 
         return nil
       end
+      # rubocop:enable Metrics/PerceivedComplexity
 
       def self.commit_author(repo_name, commit_sha, github_token)
         client = Octokit::Client.new(access_token: github_token)

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/git_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/git_helper.rb
@@ -178,12 +178,16 @@ module Fastlane
 
         UI.message("Creating draft public release #{draft_public_release_name}")
 
+        description = <<~DESCRIPTION
+          This draft release is here to indicate that the release branch is frozen.
+          New internal releases on `release/#{platform}/#{latest_marketing_version}` branch cannot be created.
+          If you need to bump the internal release, please manually delete this draft release.
+        DESCRIPTION
+
         other_action.set_github_release(
           repository_name: repo_name,
           api_bearer: github_token,
-          description: "This draft release is here to indicate that the release branch is frozen.
-          New internal releases on `release/#{platform}/#{latest_marketing_version}` branch cannot be created.
-          If you need to bump the internal release, please manually delete this draft release.",
+          description: description,
           name: draft_public_release_name,
           tag_name: "",
           is_draft: true,

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/git_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/git_helper.rb
@@ -207,8 +207,9 @@ module Fastlane
         if latest_public_release.name == draft_public_release_name && latest_public_release.draft
           UI.important("Draft public release #{draft_public_release_name} exists, which means the release branch is frozen.")
           UI.error("🚨 If you need to bump the release:")
-          UI.error(" - delete the draft public release at #{latest_public_release.html_url} to unfreeze the branch")
-          UI.error(" - restart the workflow.")
+          UI.error(" - Delete the draft public release to unfreeze the branch")
+          UI.error("    - Release URL: ➡️ #{latest_public_release.html_url} ⬅️")
+          UI.error(" - Restart the workflow")
           UI.user_error!("Release branch is frozen.")
           return
         end

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/git_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/git_helper.rb
@@ -204,9 +204,12 @@ module Fastlane
         latest_public_release = latest_release(repo_name, false, platform, github_token, allow_drafts: true)
         UI.success("Latest public release (including drafts): #{latest_public_release.name}")
 
-        if latest_public_release.name == draft_public_release_name
-          UI.error("Draft public release #{draft_public_release_name} exists, which means the release branch is frozen.")
-          UI.user_error!("Delete the draft public release at #{latest_public_release.html_url} to unfreeze the branch and restart the workflow.")
+        if latest_public_release.name == draft_public_release_name && latest_public_release.draft
+          UI.important("Draft public release #{draft_public_release_name} exists, which means the release branch is frozen.")
+          UI.error("🚨 If you need to bump the release:")
+          UI.error(" - delete the draft public release at #{latest_public_release.html_url} to unfreeze the branch")
+          UI.error(" - restart the workflow.")
+          UI.user_error!("Release branch is frozen.")
           return
         end
 

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/git_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/git_helper.rb
@@ -244,7 +244,7 @@ module Fastlane
 
         UI.message("Release version matches and it's a draft release.")
         UI.important("Deleting draft public release #{draft_public_release_name}")
-        delete_release(latest_public_release.url)
+        delete_release(latest_public_release.url, github_token)
         UI.success("Draft public release #{draft_public_release_name} deleted")
       end
 

--- a/lib/fastlane/plugin/ddg_apple_automation/version.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module DdgAppleAutomation
-    VERSION = "2.11.0"
+    VERSION = "3.0.0"
   end
 end

--- a/spec/freeze_release_branch_action_spec.rb
+++ b/spec/freeze_release_branch_action_spec.rb
@@ -1,0 +1,40 @@
+describe Fastlane::Actions::FreezeReleaseBranchAction do
+  describe "#run" do
+    subject do
+      configuration = Fastlane::ConfigurationHelper.parse(Fastlane::Actions::FreezeReleaseBranchAction, params)
+      Fastlane::Actions::FreezeReleaseBranchAction.run(configuration)
+    end
+
+    let(:params) do
+      {
+        platform: "ios",
+        github_token: "github-token"
+      }
+    end
+
+    before do
+      allow(Fastlane::Helper::GitHelper).to receive(:freeze_release_branch)
+      allow(Fastlane::UI).to receive(:important)
+      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:report_error)
+    end
+
+    it "calls helper" do
+      subject
+      expect(Fastlane::Helper::GitHelper).to have_received(:freeze_release_branch)
+      expect(Fastlane::UI).not_to have_received(:important)
+      expect(Fastlane::Helper::DdgAppleAutomationHelper).not_to have_received(:report_error)
+    end
+
+    context "when helper fails" do
+      before do
+        allow(Fastlane::Helper::GitHelper).to receive(:freeze_release_branch).and_raise("error")
+      end
+
+      it "reports error" do
+        subject
+        expect(Fastlane::UI).to have_received(:important)
+        expect(Fastlane::Helper::DdgAppleAutomationHelper).to have_received(:report_error)
+      end
+    end
+  end
+end

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -77,6 +77,100 @@ describe Fastlane::Helper::GitHelper do
     end
   end
 
+  describe "#find_latest_marketing_version" do
+    subject { Fastlane::Helper::GitHelper.find_latest_marketing_version("token", "ios") }
+
+    before do
+      @client = double
+      allow(Octokit::Client).to receive(:new).and_return(@client)
+    end
+
+    it "returns the latest marketing version" do
+      allow(@client).to receive(:releases).and_return(
+        [
+          double(tag_name: '2.0.0-1', prerelease: true),
+          double(tag_name: '2.0.0-0+ios', prerelease: true),
+          double(tag_name: '1.0.0', prerelease: false),
+          double(tag_name: '1.0.0-1', prerelease: true),
+          double(tag_name: '1.0.0-0', prerelease: true)
+        ]
+      )
+
+      expect(subject).to eq("2.0.0")
+    end
+
+    it "strips build number and platform suffix from the latest marketing version" do
+      allow(@client).to receive(:releases).and_return(
+        [
+          double(tag_name: '2.0.0-1+ios', prerelease: true)
+        ]
+      )
+
+      expect(subject).to eq("2.0.0")
+    end
+
+    it "strips platform suffix from the latest marketing version when it's a public release" do
+      allow(@client).to receive(:releases).and_return(
+        [
+          double(tag_name: '2.0.0+ios', prerelease: true)
+        ]
+      )
+
+      expect(subject).to eq("2.0.0")
+    end
+
+    describe "when there is no latest release" do
+      it "shows error" do
+        allow(@client).to receive(:releases).and_return([])
+        allow(Fastlane::UI).to receive(:user_error!)
+
+        subject
+
+        expect(Fastlane::UI).to have_received(:user_error!).with("Failed to find latest marketing version")
+      end
+    end
+
+    describe "when latest release is not a valid semver" do
+      it "shows error" do
+        allow(@client).to receive(:releases).and_return([double(tag_name: '1.0+ios', prerelease: true)])
+        allow(Fastlane::UI).to receive(:user_error!)
+
+        subject
+
+        expect(Fastlane::UI).to have_received(:user_error!).with("Invalid marketing version: 1.0, expected format: MAJOR.MINOR.PATCH")
+      end
+    end
+  end
+
+  describe "#extract_version_from_tag_name" do
+    it "returns the version" do
+      expect(extract_version_from_tag_name("1.0.0")).to eq("1.0.0")
+      expect(extract_version_from_tag_name("v1.0.0")).to eq("v1.0.0")
+      expect(extract_version_from_tag_name("1.105.0-251")).to eq("1.105.0")
+    end
+
+    def extract_version_from_tag_name(tag_name)
+      Fastlane::Helper::GitHelper.extract_version_from_tag_name(tag_name)
+    end
+  end
+
+  describe "#validate_semver" do
+    it "validates semantic version" do
+      expect(validate_semver("1.0.0")).to be_truthy
+      expect(validate_semver("0.0.0")).to be_truthy
+      expect(validate_semver("7.136.1")).to be_truthy
+
+      expect(validate_semver("v1.0.0")).to be_falsy
+      expect(validate_semver("7.1")).to be_falsy
+      expect(validate_semver("1.105.0-251")).to be_falsy
+      expect(validate_semver("1005")).to be_falsy
+    end
+
+    def validate_semver(version)
+      Fastlane::Helper::GitHelper.validate_semver(version)
+    end
+  end
+
   describe "#latest_release" do
     subject { Fastlane::Helper::GitHelper.latest_release(repo_name, prerelease, platform, github_token) }
 

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -318,6 +318,22 @@ describe Fastlane::Helper::GitHelper do
     end
   end
 
+  describe "#delete_release" do
+    subject { Fastlane::Helper::GitHelper.delete_release(release_url, github_token) }
+    let(:release_url) { "https://api.github.com/repos/duckduckgo/apple-browsers/releases/1234567890" }
+
+    include_context "common setup"
+
+    before do
+      allow(client).to receive(:delete_release)
+    end
+
+    it "deletes the release" do
+      subject
+      expect(client).to have_received(:delete_release).with(release_url)
+    end
+  end
+
   describe "#assert_branch_has_changes" do
     subject { Fastlane::Helper::GitHelper.assert_branch_has_changes("release_branch", platform) }
 

--- a/spec/git_helper_spec.rb
+++ b/spec/git_helper_spec.rb
@@ -154,6 +154,22 @@ describe Fastlane::Helper::GitHelper do
     end
   end
 
+  describe "#extract_version_from_branch_name" do
+    it "returns the version" do
+      expect(extract_version_from_branch_name("main")).to be_nil
+      expect(extract_version_from_branch_name("feature/test")).to be_nil
+      expect(extract_version_from_branch_name("release/1.2.3")).to eq("1.2.3")
+      expect(extract_version_from_branch_name("release/ios/1.2.3")).to eq("1.2.3")
+      expect(extract_version_from_branch_name("release/macos/1.2.3")).to eq("1.2.3")
+      expect(extract_version_from_branch_name("release/macos/some-text")).to be_nil
+      expect(extract_version_from_branch_name("release/macos/1.2")).to be_nil
+    end
+
+    def extract_version_from_branch_name(branch_name)
+      Fastlane::Helper::GitHelper.extract_version_from_branch_name(branch_name)
+    end
+  end
+
   describe "#validate_semver" do
     it "validates semantic version" do
       expect(validate_semver("1.0.0")).to be_truthy

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,7 +3,10 @@ $LOAD_PATH.unshift(File.expand_path('../lib', __dir__))
 require 'simplecov'
 
 # SimpleCov.minimum_coverage 95
-SimpleCov.start
+SimpleCov.start do
+  # Exclude all spec files from coverage
+  add_filter '/spec/'
+end
 
 # This module is only used to check the environment is currently a testing env
 module SpecHelper

--- a/spec/tag_release_action_spec.rb
+++ b/spec/tag_release_action_spec.rb
@@ -85,6 +85,7 @@ describe Fastlane::Actions::TagReleaseAction do
       allow(Fastlane::Actions::TagReleaseAction).to receive(:create_tag_and_github_release).and_return(@tag_and_release_output)
       allow(Fastlane::Actions::TagReleaseAction).to receive(:merge_or_delete_branch)
       allow(Fastlane::Actions::TagReleaseAction).to receive(:report_status)
+      allow(Fastlane::Helper::GitHelper).to receive(:unfreeze_release_branch)
     end
 
     context "when tag is created" do

--- a/spec/tag_release_action_spec.rb
+++ b/spec/tag_release_action_spec.rb
@@ -5,7 +5,8 @@ shared_context "common setup" do
       asana_task_url: "https://app.asana.com/0/0/1/f",
       ignore_untagged_commits: false,
       is_prerelease: true,
-      github_token: "github-token"
+      github_token: "github-token",
+      platform: "macos"
     }
     @tag_and_release_output = {}
     allow(Fastlane::Helper).to receive(:setup_git_user)
@@ -191,6 +192,33 @@ describe Fastlane::Actions::TagReleaseAction do
             expect(Fastlane::UI).to have_received(:important).with("Merging release branch to base branch failed. Cannot proceed with the public release. Please merge manually and run the workflow again.")
             expect(Fastlane::Helper::GitHubActionsHelper).to have_received(:set_output).with("stop_workflow", true)
             expect(Fastlane::Actions::TagReleaseAction).not_to have_received(:report_status)
+          end
+        end
+
+        it "unfreezes release branch if needed" do
+          subject
+          expect(Fastlane::Helper::GitHelper).to have_received(:unfreeze_release_branch)
+            .with("release_branch", "macos", @params[:github_token])
+        end
+
+        context "when unfreezing release branch fails" do
+          let(:task_id) { "1234567890" }
+
+          before do
+            allow(Fastlane::Helper::GitHelper).to receive(:unfreeze_release_branch).and_raise(StandardError)
+            allow(Fastlane::Helper::GitHubActionsHelper).to receive(:set_output)
+            allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:report_error)
+            allow(Fastlane::Actions::AsanaExtractTaskIdAction).to receive(:run).and_return(task_id)
+            allow(Fastlane::Actions::AsanaReportFailedWorkflowAction).to receive(:run)
+          end
+
+          it "reports error" do
+            subject
+            expect(Fastlane::UI).to have_received(:important).with("Failed to unfreeze release branch. Cannot proceed with the public release. Please unfreeze manually and run the workflow again.")
+            expect(Fastlane::Helper::GitHubActionsHelper).to have_received(:set_output).with("stop_workflow", true)
+            expect(Fastlane::Helper::DdgAppleAutomationHelper).to have_received(:report_error).with(StandardError)
+            expect(Fastlane::Actions::AsanaExtractTaskIdAction).to have_received(:run)
+            expect(Fastlane::Actions::AsanaReportFailedWorkflowAction).to have_received(:run).with(hash_including(task_id: task_id))
           end
         end
       end

--- a/spec/validate_internal_release_bump_action_spec.rb
+++ b/spec/validate_internal_release_bump_action_spec.rb
@@ -9,6 +9,7 @@ describe Fastlane::Actions::ValidateInternalReleaseBumpAction do
       }
 
       allow(Fastlane::Helper::GitHelper).to receive(:setup_git_user)
+      allow(Fastlane::Helper::GitHelper).to receive(:assert_release_branch_is_not_frozen)
       allow(Fastlane::Helper::GitHelper).to receive(:assert_branch_has_changes).and_return(true)
       allow(Fastlane::Helper::GitHubActionsHelper).to receive(:set_output)
       allow(Fastlane::Helper::AsanaHelper).to receive(:fetch_release_notes).and_return("Valid release notes")


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1201899738287924/task/1211100722861854?focus=true

This change adds a new freeze_release_branch_action that is called by the “promote”
workflow on Fridays. The branch is then unfrozen by tag_release_action when run for
a public release (if a branch wasn’t frozen, it handles it gracefully - this will be the case
for hotfixes). Internal release bump workflows run validate_internal_release_bump_action
that now starts with a check for a frozen branch, and if that fails, the workflow is stopped.