### PR TITLE
Filter out inaccessible tasks when constructing release notes

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/helper/asana_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/asana_helper.rb
@@ -231,7 +231,7 @@ module Fastlane
 
         UI.message("Extracting task IDs from git log since #{latest_public_release.tag_name} release")
         task_ids = get_task_ids_from_git_log(latest_public_release.tag_name)
-          .filter { |task_id| validate_task_accessible(task_id, params[:asana_access_token]) }
+                   .filter { |task_id| validate_task_accessible(task_id, params[:asana_access_token]) }
         UI.success("#{task_ids.count} task(s) found.")
 
         UI.message("Fetching release notes from Asana release task (#{asana_task_url(params[:release_task_id])})")

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/asana_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/asana_helper.rb
@@ -231,6 +231,7 @@ module Fastlane
 
         UI.message("Extracting task IDs from git log since #{latest_public_release.tag_name} release")
         task_ids = get_task_ids_from_git_log(latest_public_release.tag_name)
+          .filter { |task_id| validate_task_accessible(task_id, params[:asana_access_token]) }
         UI.success("#{task_ids.count} task(s) found.")
 
         UI.message("Fetching release notes from Asana release task (#{asana_task_url(params[:release_task_id])})")
@@ -426,6 +427,15 @@ module Fastlane
           .map { |task_line| task_line.gsub(/.*(https.*)/, '\1') }
           .map { |task_url| extract_asana_task_id(task_url, set_gha_output: false) }
           .uniq
+      end
+
+      def self.validate_task_accessible(task_id, asana_access_token)
+        asana_client = make_asana_client(asana_access_token)
+        asana_client.tasks.get_task(task_gid: task_id, options: { fields: ["gid"] })
+        true
+      rescue StandardError => e
+        UI.important("Failed to fetch #{task_id}, ignoring. Error: #{e}")
+        false
       end
 
       def self.fetch_release_notes(release_task_id, asana_access_token, output_type: "asana")

--- a/lib/fastlane/plugin/ddg_apple_automation/version.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module DdgAppleAutomation
-    VERSION = "3.0.0"
+    VERSION = "3.1.0"
   end
 end


### PR DESCRIPTION
Asana Task URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1211354468416267?focus=true

This change filters out tasks that are inaccessible from the list of tasks to be processed by the automation.

Proof that filtering works, as tested from the command line for https://app.asana.com/0/0/1211009642249879:
```
$ irb
Resolving dependencies...
3.3.4 :001 > require_relative 'lib/fastlane/plugin/ddg_apple_automation/helper/asana_helper'
 => true
3.3.4 :002 > ["1211009642249879"].filter { |task_id| Fastlane::Helper::AsanaHelper.validate_task_accessible(task_id, ENV["ASANA_ACCESS_TOKEN"]) }
[12:07:56]: Failed to fetch 1211009642249879, ignoring. Error: The authorization and request syntax was valid but the server is refusing to complete the request. This can happen if you try to read or write to objects or properties that the user does not have access to.
 => []
3.3.4 :003 >
```