### PR TITLE
Remove increment_build_number from macOS hotfix branch prep

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/actions/start_new_release_action.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/actions/start_new_release_action.rb
@@ -19,7 +19,7 @@ module Fastlane
 
         if params[:is_hotfix]
           release_branch_name, new_version = Helper::DdgAppleAutomationHelper.prepare_hotfix_branch(
-            params[:github_token], params[:platform], other_action, options
+            params[:github_token], params[:platform], other_action
           )
         else
           release_branch_name, new_version, show_update_embedded_warning = Helper::DdgAppleAutomationHelper.prepare_release_branch(

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
@@ -160,7 +160,6 @@ module Fastlane
           update_version_config(new_version, other_action)
         end
         other_action.push_to_git_remote
-        increment_build_number(platform, options, other_action) if platform == "macos"
         Helper::GitHubActionsHelper.set_output("release_branch_name", release_branch_name)
         commit_sha = other_action.last_git_commit[:commit_hash]
         Helper::GitHubActionsHelper.set_output("commit_sha", commit_sha)

--- a/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/helper/ddg_apple_automation_helper.rb
@@ -145,7 +145,7 @@ module Fastlane
         return release_branch_name, new_version, update_embedded_result
       end
 
-      def self.prepare_hotfix_branch(github_token, platform, other_action, options)
+      def self.prepare_hotfix_branch(github_token, platform, other_action)
         latest_public_release = Helper::GitHelper.latest_release(Helper::GitHelper.repo_name, false, platform, github_token)
         version = latest_public_release.tag_name
         Helper::GitHubActionsHelper.set_output("last_release", version)

--- a/lib/fastlane/plugin/ddg_apple_automation/version.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module DdgAppleAutomation
-    VERSION = "4.0.2"
+    VERSION = "4.1.0"
   end
 end

--- a/spec/ddg_apple_automation_helper_spec.rb
+++ b/spec/ddg_apple_automation_helper_spec.rb
@@ -426,9 +426,6 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
       allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:update_version_config)
         .with(new_version, other_action)
 
-      allow(Fastlane::Helper::DdgAppleAutomationHelper).to receive(:increment_build_number)
-        .with(platform, options, other_action)
-
       allow(Fastlane::Helper::GitHubActionsHelper).to receive(:set_output)
 
       expect(other_action).to receive(:push_to_git_remote)
@@ -445,7 +442,6 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
       expect(Fastlane::Helper::DdgAppleAutomationHelper).to have_received(:validate_hotfix_version).with(source_version)
       expect(Fastlane::Helper::DdgAppleAutomationHelper).to have_received(:create_hotfix_branch).with(platform, source_version, new_version)
       expect(Fastlane::Helper::DdgAppleAutomationHelper).to have_received(:update_version_config).with(new_version, other_action)
-      expect(Fastlane::Helper::DdgAppleAutomationHelper).to have_received(:increment_build_number).with(platform, options, other_action)
       expect(Fastlane::Helper::GitHubActionsHelper).to have_received(:set_output).with("last_release", source_version)
       expect(Fastlane::Helper::GitHubActionsHelper).to have_received(:set_output).with("release_branch_name", release_branch_name)
       expect(Fastlane::Helper::GitHubActionsHelper).to have_received(:set_output).with("commit_sha", "abc123")

--- a/spec/ddg_apple_automation_helper_spec.rb
+++ b/spec/ddg_apple_automation_helper_spec.rb
@@ -407,7 +407,6 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
       new_version = "1.0.1+#{platform}"
       release_branch_name = "hotfix/#{platform}/1.0.1"
       other_action = double("other_action")
-      options = { some_option: "value" }
       github_token = "github-token"
 
       @client = double("Octokit::Client")
@@ -432,7 +431,7 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
       expect(other_action).to receive(:last_git_commit).and_return({ commit_hash: "abc123" })
 
       result_branch, result_version = Fastlane::Helper::DdgAppleAutomationHelper.prepare_hotfix_branch(
-        github_token, platform, other_action, options
+        github_token, platform, other_action
       )
 
       expect(result_branch).to eq(release_branch_name)
@@ -454,7 +453,6 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
       new_version = "1.0.1+#{platform}"
       release_branch_name = "hotfix/#{platform}/1.0.1"
       other_action = double("other_action")
-      options = { some_option: "value" }
       github_token = "github-token"
 
       @client = double("Octokit::Client")
@@ -482,7 +480,7 @@ describe Fastlane::Helper::DdgAppleAutomationHelper do
       expect(other_action).to receive(:last_git_commit).and_return({ commit_hash: "abc123" })
 
       result_branch, result_version = Fastlane::Helper::DdgAppleAutomationHelper.prepare_hotfix_branch(
-        github_token, platform, other_action, options
+        github_token, platform, other_action
       )
 
       expect(result_branch).to eq(release_branch_name)

--- a/spec/start_new_release_action_spec.rb
+++ b/spec/start_new_release_action_spec.rb
@@ -192,7 +192,7 @@ describe Fastlane::Actions::StartNewReleaseAction do
         it "prepares the hotfix branch" do
           subject
           expect(Fastlane::Helper::DdgAppleAutomationHelper).to have_received(:prepare_hotfix_branch)
-            .with("github_token", "macos", anything, hash_including(asana_user_id: "user"))
+            .with("github_token", "macos", anything)
         end
 
         it "creates a hotfix release task in Asana" do


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1203301625297703/task/1213798709649793

### Description

Remove the `increment_build_number` call from `prepare_hotfix_branch`. This step was only executed for macOS hotfixes and is no longer needed as part of hotfix branch preparation.

Also bumps the plugin version to 4.1.0.

### Testing Steps
Verify that tests pass

### Impact and Risks

**Low**

#### What could go wrong?

- macOS hotfix workflows that previously relied on `increment_build_number` being called during branch preparation would need to handle build number incrementing separately. This is expected and intentional.

### Quality Considerations

- Corresponding test expectations have been updated to reflect the removal
- No other callers of `increment_build_number` are affected

---
**Generated with [Claude Code](https://claude.ai/code)**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes release automation behavior for macOS hotfixes and updates the `prepare_hotfix_branch` API, which could impact existing CI/lane callers if any are missed.
> 
> **Overview**
> Hotfix branch preparation no longer increments the build number for macOS: `DdgAppleAutomationHelper.prepare_hotfix_branch` drops the `increment_build_number` step and removes its `options` parameter.
> 
> `StartNewReleaseAction` and the associated specs are updated to match the new helper signature/behavior, and the plugin version is bumped to `4.1.0`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa38cc13fad9d99648c4691f486dbf94c7eca32b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->