### PR TITLE
Document iOS ad-hoc Asana comment template

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3386,6 +3386,7 @@
               <tr><td><code>hotfix-branch-ready</code></td><td>Notifies that a hotfix branch has been created</td><td>Phase 1 of hotfix flow</td></tr>
               <tr><td><code>debug-symbols-uploaded</code></td><td>Confirms dSYM upload to S3</td><td>After successful notarized build</td></tr>
               <tr><td><code>dmg-uploaded</code></td><td>Confirms DMG artifact upload to S3</td><td>After DMG creation</td></tr>
+              <tr><td><code>ios-adhoc-build-available</code></td><td>Lists iOS ad-hoc install, IPA, dSYM, and workflow links</td><td>After successful iOS ad-hoc build with Asana URL</td></tr>
               <tr><td><code>internal-release-ready</code></td><td>Signals internal release tagged successfully</td><td>After successful internal tag</td></tr>
               <tr><td><code>internal-release-ready-merge-failed</code></td><td>Internal release tagged but merge failed</td><td>When tag succeeds but merge fails (internal)</td></tr>
               <tr><td><code>internal-release-ready-tag-failed</code></td><td>Internal release tag failed</td><td>When tag_release fails for internal</td></tr>


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1214633075025736?focus=true

### Description

Adds the `ios-adhoc-build-available` Asana comment template to the GitHub Pages documentation template table.

This keeps the published fastlane plugin docs aligned with the new template added in `4.1.2` and consumed by the companion `apple-browsers` iOS ad-hoc workflow.

### Testing Steps

`git diff --check` - clean.

### Impact and Risks

Low. This is a docs-only change and does not alter plugin behavior.

#### What could go wrong?

- The docs row could drift from the workflow/template behavior if the iOS ad-hoc Asana comment changes later.

### Quality Considerations

- The new row follows the existing Asana comment template table format.
- No runtime behavior changes.

### Notes to Reviewer

Follow-up to https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation/pull/69 and companion change: https://github.com/duckduckgo/apple-browsers/pull/4791.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1207907750784498/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/184709971311741)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that adds a single row to the generated GitHub Pages table; no automation/runtime behavior is affected.
> 
> **Overview**
> **Updates the GitHub Pages documentation** by adding the `ios-adhoc-build-available` entry to the Asana comment template reference table in `docs/index.html`, describing its purpose and when it’s posted (after a successful iOS ad-hoc build with an Asana URL).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3225788905d571c8e2b1514d9d1d22e54d3eaa50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->