### PR TITLE
Improve iOS ad-hoc Asana comment template

### DIFF
--- a/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/ios-adhoc-build-available.html.erb
+++ b/lib/fastlane/plugin/ddg_apple_automation/assets/asana_add_comment/templates/ios-adhoc-build-available.html.erb
@@ -1,9 +1,10 @@
 <body>
-  <strong><%= defined?(title) && !title.to_s.strip.empty? ? title : "DuckDuckGo iOS" %> <%= app_version %> (<%= build_number %>)</strong>
+  <h2><%= defined?(title) && !title.to_s.strip.empty? ? title : "DuckDuckGo iOS" %> <%= app_version %> (<%= build_number %>) ready ✅</h2>
   <ul>
-<% if defined?(install_url) && !install_url.to_s.strip.empty? %>    <li><a href='<%= install_url %>'>Install on iPhone</a> - open in Safari</li>
-<% end %>    <li><a href='<%= ipa_url %>'>Download IPA</a></li>
-    <li><a href='<%= dsym_url %>'>Download dSYM</a></li>
-    <li><a href='<%= workflow_url %>'>Workflow run</a></li>
+<% if defined?(install_url) && !install_url.to_s.strip.empty? %>    <li>📲 <a href='<%= install_url %>'>Install on iPhone</a>.</li>
+<% end %>    <li>📦 <a href='<%= ipa_url %>'>Download IPA</a>.</li>
+    <li>🧩 <a href='<%= dsym_url %>'>Download dSYM</a>.</li>
   </ul>
+  <br>
+  🔗 <a href='<%= workflow_url %>'>Workflow run</a>.
 </body>

--- a/lib/fastlane/plugin/ddg_apple_automation/version.rb
+++ b/lib/fastlane/plugin/ddg_apple_automation/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module DdgAppleAutomation
-    VERSION = "4.1.2"
+    VERSION = "4.1.3"
   end
 end

--- a/spec/asana_add_comment_action_spec.rb
+++ b/spec/asana_add_comment_action_spec.rb
@@ -174,13 +174,14 @@ describe Fastlane::Actions::AsanaAddCommentAction do
     it "processes ios-adhoc-build-available template" do
       expected = <<~EXPECTED
         <body>
-          <strong>DuckDuckGo Alpha 1.0.0 (123)</strong>
+          <h2>DuckDuckGo Alpha 1.0.0 (123) ready ✅</h2>
           <ul>
-            <li><a href='https://cdn.com/build.install.html'>Install on iPhone</a> - open in Safari</li>
-            <li><a href='https://cdn.com/build.ipa'>Download IPA</a></li>
-            <li><a href='https://cdn.com/build.dSYM.zip'>Download dSYM</a></li>
-            <li><a href='https://workflow.com'>Workflow run</a></li>
+            <li>📲 <a href='https://cdn.com/build.install.html'>Install on iPhone</a>.</li>
+            <li>📦 <a href='https://cdn.com/build.ipa'>Download IPA</a>.</li>
+            <li>🧩 <a href='https://cdn.com/build.dSYM.zip'>Download dSYM</a>.</li>
           </ul>
+          <br>
+          🔗 <a href='https://workflow.com'>Workflow run</a>.
         </body>
       EXPECTED
 
@@ -198,12 +199,13 @@ describe Fastlane::Actions::AsanaAddCommentAction do
     it "processes ios-adhoc-build-available template without install url" do
       expected = <<~EXPECTED
         <body>
-          <strong>DuckDuckGo iOS 1.0.0 (123)</strong>
+          <h2>DuckDuckGo iOS 1.0.0 (123) ready ✅</h2>
           <ul>
-            <li><a href='https://cdn.com/build.ipa'>Download IPA</a></li>
-            <li><a href='https://cdn.com/build.dSYM.zip'>Download dSYM</a></li>
-            <li><a href='https://workflow.com'>Workflow run</a></li>
+            <li>📦 <a href='https://cdn.com/build.ipa'>Download IPA</a>.</li>
+            <li>🧩 <a href='https://cdn.com/build.dSYM.zip'>Download dSYM</a>.</li>
           </ul>
+          <br>
+          🔗 <a href='https://workflow.com'>Workflow run</a>.
         </body>
       EXPECTED
 


### PR DESCRIPTION
Task/Issue URL: https://app.asana.com/1/137249556945/project/1214200115953388/task/1214633075025736?focus=true

### Description

Improves the `ios-adhoc-build-available` Asana comment template for iOS ad-hoc build notifications.

The template now matches the style of the existing release automation comments more closely: it uses a `ready` heading with a status emoji, emoji-prefixed artifact links, friendly link labels instead of visible raw URLs, and a separate workflow run link.

Also bumps the plugin version to `4.1.3`.

### Testing Steps

`bundle exec rake` - all specs pass and RuboCop is clean.

### Impact and Risks

Low. This only changes the rendered output of the iOS ad-hoc Asana comment template.

#### What could go wrong?

- The companion `apple-browsers` workflow must consume a plugin tag that includes this template update; otherwise it will keep rendering the previous template style.
- Link labels could hide useful artifact URLs in the visible comment, but the links still point to the same install page, IPA, dSYM, and workflow run.

### Quality Considerations

- Updated specs cover both install-link and no-install-link rendering.
- The template follows the existing `asana_add_comment` ERB template pattern and file-ending convention.

### Notes to Reviewer

Follow-up to https://github.com/duckduckgo/fastlane-plugin-ddg_apple_automation/pull/69 and companion change: https://github.com/duckduckgo/apple-browsers/pull/4791.

---
###### Internal references:
[Pull Request Review Checklist](https://app.asana.com/0/1202500774821704/1207907750784498/f)
[Software Engineering Expectations](https://app.asana.com/0/59792373528535/184709971311741)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only adjust the rendered HTML for the `ios-adhoc-build-available` Asana comment template and bump the gem version, with no logic or API behavior changes.
> 
> **Overview**
> Updates the `ios-adhoc-build-available` Asana comment template to a more consistent, user-friendly format: a `ready ✅` heading, emoji-labeled artifact links (optional install link, IPA, dSYM), and the workflow run link moved out of the list.
> 
> Bumps plugin version from `4.1.2` to `4.1.3` and updates specs to match the new rendered output (with and without `install_url`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b5f656a6bf13d8a905f56485461e1237709bc1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->